### PR TITLE
Adding messages

### DIFF
--- a/streamz/core.py
+++ b/streamz/core.py
@@ -36,9 +36,7 @@ class IgnoreMSG:
     pass
 
 
-class StopMSG:
-    pass
-
+# perhaps StopMSG?
 
 def identity(x):
     return x
@@ -412,7 +410,7 @@ class sink(Stream):
 
     def update(self, x, who=None):
         # only if not a clear msg, which is ignored
-        if not isinstance(x, ClearMSG):
+        if not isinstance(x, ClearMSG) and not isinstance(x, IgnoreMSG):
             result = self.func(x, *self.args, **self.kwargs)
             if gen.isawaitable(result):
                 return result
@@ -454,6 +452,9 @@ class map(Stream):
         Stream.__init__(self, upstream, stream_name=stream_name)
 
     def update(self, x, who=None):
+        if isinstance(x, IgnoreMSG) or isinstance(x, ClearMSG):
+            return self.emit(x)
+
         result = self.func(x, *self.args, **self.kwargs)
 
         return self._emit(result)
@@ -544,6 +545,9 @@ class accumulate(Stream):
         if isinstance(x, ClearMSG):
             self.state = self.start
             # and pass it through
+            return self.emit(x)
+
+        if isinstance(x, IgnoreMSG):
             return self.emit(x)
 
         if self.state is no_default:

--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -938,16 +938,21 @@ def test_clear():
     # increment
     def acc1(x1, x2):
         return x1 + x2
-    from streamz.core import ClearMSG
+    from streamz.core import ClearMSG, IgnoreMSG
 
-    cc = ClearMSG()
+    clear_msg = ClearMSG()
+    ignore_msg = IgnoreMSG()
 
     sout = s.accumulate(acc1)
-
     Lout = sout.sink_to_list()
+    sout2 = sout.map(lambda x : x + 1)
+    Lout2 = sout2.sink_to_list()
 
     s.emit(1)
     s.emit(2)
-    s.emit(cc)
+    s.emit(ignore_msg)
     s.emit(3)
-    assert Lout == [1, 3, 3]
+    s.emit(clear_msg)
+    s.emit(3)
+    assert Lout == [1, 3, 6, 3]
+    assert Lout2 == [2, 4, 7, 4]

--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -931,3 +931,23 @@ def test_separate_thread_with_time(loop, thread):
 
 if sys.version_info >= (3, 5):
     from streamz.tests.py3_test_core import *  # noqa
+
+
+def test_clear():
+    s = Stream()
+    # increment
+    def acc1(x1, x2):
+        return x1 + x2
+    from streamz.core import ClearMSG
+
+    cc = ClearMSG()
+
+    sout = s.accumulate(acc1)
+
+    Lout = sout.sink_to_list()
+
+    s.emit(1)
+    s.emit(2)
+    s.emit(cc)
+    s.emit(3)
+    assert Lout == [1, 3, 3]


### PR DESCRIPTION
Should we allow messages to pass? I think something like this would be useful.

For example here, we send a clear message which should clear various elements of the stream that hold state. Right now, only this is performed:
```python
    s = Stream()
    # increment
    def acc1(x1, x2):
        return x1 + x2
    from streamz.core import ClearMSG

    cc = ClearMSG()

    sout = s.accumulate(acc1)

    Lout = sout.sink_to_list()

    s.emit(1)
    s.emit(2)
    s.emit(cc)
    s.emit(3)
    assert Lout == [1, 3, 3]
```

but I'd find this useful. One could change these messages to node specific, like "CLEAR_ACC", or some control stream with flags like: `Clear(clear_acc=True,...)`.

any thoughts? This is meant to open discussion. I find it more convenient than an issue in this case.
The various messages or message handler can perhaps also be handled by dispatching, to allow for more convenient subclassing.

This was a quick thought. If it's of interest in the base class we can discuss adding more.