### PR TITLE
Bug timed window

### DIFF
--- a/examples/fib_asyncio.py
+++ b/examples/fib_asyncio.py
@@ -9,7 +9,7 @@ s = source.sliding_window(2).map(sum)
 L = s.sink_to_list()                    # store result in a list
 
 s.rate_limit(0.5).sink(source.emit)         # pipe output back to input
-s.rate_limit(1.0).sink(lambda x: print(L))  # print state of L every second
+s.timed_window(1.0).sink(lambda x: print(x))
 
 source.emit(0)                          # seed with initial values
 source.emit(1)

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -1130,7 +1130,14 @@ def sync(loop, func, *args, **kwargs):
         else:
             return gen.with_timeout(timedelta(seconds=timeout), coro)
 
-    if not loop._running:
+    try:
+        loop_is_running = loop._running
+    except AttributeError:
+        try:
+            loop_is_running = loop.asyncio_loop.is_running()
+        except AttributeError:
+            raise NotImplementedError(type(loop))
+    if not loop_is_running:
         try:
             return loop.run_sync(make_coro)
         except RuntimeError:  # loop already running


### PR DESCRIPTION
Very hacky workaround for the timed_window AttributeError.

It seems to me that the `AsyncIOMainLoop` in `tornado` doesn't implement `loop._running` properly (it's not implemented at all). Given that it starts with an underscore, I don't know if it forms part of the API and needs to be implemented?

This fixes the `fib_asyncio.py` example. However in the application where I discovered this and where I am trying to use it my whole app now freezes. Still investigating what's going on there. It would be good to get some more eyes on this to see if my workaround works for other people.