### PR TITLE
Add ConsumerFactory for batched kafka

### DIFF
--- a/streamz/compatibility.py
+++ b/streamz/compatibility.py
@@ -1,6 +1,6 @@
 import sys
 
-if sys.version_info[0] == 2:
+if sys.version_info[0] == 2:   # pragma: no cover
     from thread import get_ident as get_thread_identity
     import __builtin__ as builtins
 else:

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -540,6 +540,6 @@ def get_message_batch(factory, partition, low, high, timeout=None):
     if low <= high:
         try:
             consumer.commit(asynchronous=False)
-        except factory.ck.KafkaError:
+        except factory.ck.KafkaError:   # pragma: no cover
             pass
     return out

--- a/streamz/tests/test_sources.py
+++ b/streamz/tests/test_sources.py
@@ -34,7 +34,7 @@ def test_tcp():
 
 @gen_test(timeout=60)
 def test_tcp_async():
-    port = 9876
+    port = 9877
     s = Source.from_tcp(port)
     out = s.sink_to_list()
     s.start()


### PR DESCRIPTION
Inspired by #226, but in this case, consumers are thread-local,
because they should not be called simultaneously from separate threads,
and this should also work across processes.