### PR TITLE
Added from_textfile_batched() method.

### DIFF
--- a/streamz/dask.py
+++ b/streamz/dask.py
@@ -198,3 +198,8 @@ class filenames(DaskStream, sources.filenames):
 @DaskStream.register_api(staticmethod)
 class from_textfile(DaskStream, sources.from_textfile):
     pass
+
+
+@DaskStream.register_api(staticmethod)
+class from_textfile_batched(DaskStream, sources.from_textfile_batched):
+    pass


### PR DESCRIPTION
Added a from_textfile_batched() method, which takes batchSize as a parameter, and emits the corresponding-sized chunks of text downstream. 

This method is DaskStream compatible. 

Added pertinent unit test as well. 