### PR TITLE
add reset_stream to accumulate

### DIFF
--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -1164,5 +1164,40 @@ def test_start():
     assert flag == [True]
 
 
+def test_accumulate():
+    a = Stream()
+    b = a.accumulate(lambda x, y: x + y)
+    L = b.sink_to_list()
+    LL = []
+
+    for i in range(10):
+        a.emit(i)
+        if len(LL) == 0:
+            LL.append(i)
+        else:
+            LL.append(i + LL[-1])
+
+    assert L == LL
+
+
+def test_accumulate_reset():
+    a = Stream()
+    rn = Stream()
+    b = a.accumulate(lambda x, y: x + y, reset_stream=rn)
+    L = b.sink_to_list()
+    LL = []
+
+    for i in range(10):
+        if i == 5:
+            rn.emit('hi')
+        a.emit(i)
+        if len(LL) == 0 or i == 5:
+            LL.append(i)
+        else:
+            LL.append(i + LL[-1])
+
+    assert L == LL
+
+
 if sys.version_info >= (3, 5):
     from streamz.tests.py3_test_core import *  # noqa


### PR DESCRIPTION
One issue I've run into is resetting the state of accumulate nodes.
The current operating procedure is if there is a signal to clear the accumulate node, that it should send data to a sink which resets the acummulate node's state.
However this causes "spooky action at a distance" where two nodes which are completely unrelated by the graph have a very close relationship, making the structure of the pipeline more difficult to understand (naming credit to tacaswell).

This PR fixes this by providing a dedicated stream via a kwarg. 
When this stream reciveds data then the accumulate node's state is reset.
Since this stream is formally tracked by the node ``upstreams`` it is properly recoreded in the visualized graph and behaves properly when connected or disconnected.