### PR TITLE
Add support for more cudf methods with 0.7 

### DIFF
--- a/streamz/dataframe/aggregations.py
+++ b/streamz/dataframe/aggregations.py
@@ -4,8 +4,7 @@ from collections import deque
 from numbers import Number
 
 import numpy as np
-import pandas as pd
-from .utils import is_series_like, is_index_like
+from .utils import is_series_like, is_index_like, get_dataframe_package
 
 
 class Aggregation(object):
@@ -136,7 +135,8 @@ class Full(Aggregation):
     possible
     """
     def on_new(self, acc, new):
-        result = pd.concat([acc, new])
+        df_package = get_dataframe_package(new)
+        result = df_package.concat([acc, new])
         return result, result
 
     def on_old(self, acc, old):

--- a/streamz/dataframe/tests/test_dataframe_utils.py
+++ b/streamz/dataframe/tests/test_dataframe_utils.py
@@ -1,5 +1,6 @@
 import pytest
-from streamz.dataframe.utils import is_dataframe_like, is_series_like, is_index_like, get_base_frame_type
+from streamz.dataframe.utils import is_dataframe_like, is_series_like, \
+                is_index_like, get_base_frame_type, get_dataframe_package
 
 import pandas as pd
 import numpy as np
@@ -57,3 +58,18 @@ def test_utils_get_base_frame_type_cudf():
     with pytest.raises(TypeError):
         get_base_frame_type("Series", is_series_like, df.index)
     assert issubclass(get_base_frame_type("Index", is_index_like, df.index), cudf.Index)
+
+
+def test_get_dataframe_package_pandas():
+    df = pd.DataFrame({'x': np.arange(10, dtype=float), 'y': [1.0, 2.0] * 5})
+    assert pd == get_dataframe_package(df)
+    assert pd == get_dataframe_package(df.x)
+    assert pd == get_dataframe_package(df.index)
+
+
+def test_get_dataframe_package_cudf():
+    cudf = pytest.importorskip("cudf")
+    df = cudf.DataFrame({'x': np.arange(10, dtype=float), 'y': [1.0, 2.0] * 5})
+    assert cudf == get_dataframe_package(df)
+    assert cudf == get_dataframe_package(df.x)
+    assert cudf == get_dataframe_package(df.index)

--- a/streamz/dataframe/utils.py
+++ b/streamz/dataframe/utils.py
@@ -1,3 +1,9 @@
+from __future__ import division, print_function
+
+import inspect
+import sys
+
+
 def is_dataframe_like(df):
     """ Looks like a Pandas DataFrame. ** Borrowed from dask.dataframe.utils ** """
     typ = type(df)
@@ -5,7 +11,7 @@ def is_dataframe_like(df):
                 for name in ('groupby', 'head', 'merge', 'mean'))
             and all(hasattr(df, name) for name in ('dtypes',))
             and not any(hasattr(typ, name)
-                for name in ('value_counts', 'dtype')))
+                        for name in ('value_counts', 'dtype')))
 
 
 def is_series_like(s):
@@ -33,3 +39,11 @@ def get_base_frame_type(frame_name, is_frame_like, example=None):
                                              .format(frame_name, example)
         raise TypeError(msg)
     return type(example)
+
+
+def get_dataframe_package(df):
+    """ Utility function to return the top level package (pandas/cudf)
+     of DataFrame/Series/Index objects """
+    module = inspect.getmodule(df)
+    package, _, _ = module.__name__.partition('.')
+    return sys.modules[package]


### PR DESCRIPTION
The latest release of cudf 0.7 allowed me to add support for some more cudf methods. Arithmetic operations on cudf DataFrames are now supported. I have added tests for those newly supported methods in cudf. 

GroupBy is not possible yet due to some implementation differences between Pandas and cudf. But I added some github issues for these blockers.  