### PR TITLE
Tests for rolling aggregations in cudf.

### DIFF
--- a/streamz/dataframe/tests/test_cudf.py
+++ b/streamz/dataframe/tests/test_cudf.py
@@ -1,5 +1,5 @@
 """
-Tests for cudf DataFrames: 
+Tests for cudf DataFrames:
 All tests have been cloned from the test_dataframes module in the same folder.
 Some of these tests pass with cudf, and others are marked with xfail
 where a pandas-like method is not yet implemented in cudf.
@@ -7,20 +7,15 @@ But these tests should pass as and when cudf rolls out more pandas-like methods.
 """
 from __future__ import division, print_function
 
-import json
 import operator
-from time import sleep
 
 import pytest
 from dask.dataframe.utils import assert_eq
 import numpy as np
 import pandas as pd
-from tornado import gen
 
 from streamz import Stream
-from streamz.utils_test import gen_test
 from streamz.dataframe import DataFrame, Series, DataFrames, Aggregation
-import streamz.dataframe as sd
 from streamz.dask import DaskStream
 
 from distributed import Client
@@ -81,7 +76,7 @@ def test_attributes():
 
     assert getattr(sdf,'x',-1) != -1
     assert getattr(sdf,'z',-1) == -1
-    
+
     sdf.x
     with pytest.raises(AttributeError):
         sdf.z
@@ -367,7 +362,7 @@ def test_setitem_overwrites(stream):
 
     assert_eq(L[-1], df.iloc[7:] * 2)
 
-    
+
 @pytest.mark.parametrize('kwargs,op', [
     ({}, 'sum'),
     ({}, 'mean'),
@@ -378,7 +373,7 @@ def test_setitem_overwrites(stream):
     pytest.param({}, 'count'),
     pytest.param({'ddof': 0}, 'std', marks=pytest.mark.xfail(reason="Not implemented for rolling objects")),
     pytest.param({'quantile': 0.5}, 'quantile', marks=pytest.mark.xfail(reason="Not implemented for rolling objects")),
-    pytest.param({'arg': {'A': 'sum', 'B': 'min'}}, 'aggregate', marks=pytest.mark.xfail(reason="Not implemented for rolling objects"))
+    pytest.param({'arg': {'A': 'sum', 'B': 'min'}}, 'aggregate', marks=pytest.mark.xfail(reason="Not implemented"))
 ])
 @pytest.mark.parametrize('window', [
     pytest.param(2),
@@ -393,7 +388,7 @@ def test_setitem_overwrites(stream):
 @pytest.mark.parametrize('pre_get,post_get', [
     (lambda df: df, lambda df: df),
     (lambda df: df.x, lambda x: x),
-    pytest.param(lambda df: df, lambda df: df.x, marks=pytest.mark.xfail(reason="Cannot select columns for rolling over time objects"))
+    (lambda df: df, lambda df: df.x)
 ])
 def test_rolling_count_aggregations(op, window, m, pre_get, post_get, kwargs,
         stream):
@@ -413,8 +408,8 @@ def test_rolling_count_aggregations(op, window, m, pre_get, post_get, kwargs,
     assert len(L) > 1
 
     assert_eq(cudf.concat(L), expected)
-    
-    
+
+
 def test_stream_to_dataframe(stream):
     df = cudf.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
     source = stream
@@ -436,6 +431,7 @@ def test_to_frame(stream):
     a = sdf.x.to_frame()
     assert isinstance(a, DataFrame)
     assert list(a.columns) == ['x']
+
 
 @pytest.mark.parametrize('op', ['cumsum', 'cummax', 'cumprod', 'cummin'])
 @pytest.mark.parametrize('getter', [lambda df: df, lambda df: df.x])

--- a/streamz/dataframe/tests/test_cudf.py
+++ b/streamz/dataframe/tests/test_cudf.py
@@ -1,9 +1,9 @@
 """
-Tests for cudf DataFrame
-All these tests are taken from test_dataframes module in the same folder.
-Some of these tests pass with cudf as they are, and others are marked xfail
-where a pandas like method is not implemented yet in cudf.
-But these tests should pass as cudf implement more pandas like methods.
+Tests for cudf DataFrames: 
+All tests have been cloned from the test_dataframes module in the same folder.
+Some of these tests pass with cudf, and others are marked with xfail
+where a pandas-like method is not yet implemented in cudf.
+But these tests should pass as and when cudf rolls out more pandas-like methods.
 """
 from __future__ import division, print_function
 

--- a/streamz/dataframe/tests/test_cudf.py
+++ b/streamz/dataframe/tests/test_cudf.py
@@ -79,9 +79,9 @@ def test_attributes():
     df = cudf.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
     sdf = DataFrame(example=df)
 
-    assert 'x' in dir(sdf)
-    assert 'z' not in dir(sdf)
-
+    assert getattr(sdf,'x',-1) != -1
+    assert getattr(sdf,'z',-1) == -1
+    
     sdf.x
     with pytest.raises(AttributeError):
         sdf.z
@@ -436,25 +436,6 @@ def test_to_frame(stream):
     a = sdf.x.to_frame()
     assert isinstance(a, DataFrame)
     assert list(a.columns) == ['x']
-
-
-def test_instantiate_with_dict(stream):
-    df = cudf.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
-    sdf = DataFrame(example=df, stream=stream)
-
-    sdf2 = DataFrame({'a': sdf.x, 'b': sdf.x * 2,
-                      'c': sdf.y % 2})
-    L = sdf2.stream.gather().sink_to_list()
-    assert len(sdf2.columns) == 3
-
-    sdf.emit(df)
-    sdf.emit(df)
-
-    assert len(L) == 2
-    for x in L:
-        assert_eq(x[['a', 'b', 'c']],
-                  cudf.DataFrame({'a': df.x, 'b': df.x * 2, 'c': df.y % 2}))
-
 
 @pytest.mark.parametrize('op', ['cumsum', 'cummax', 'cumprod', 'cummin'])
 @pytest.mark.parametrize('getter', [lambda df: df, lambda df: df.x])

--- a/streamz/dataframe/tests/test_dataframe_utils.py
+++ b/streamz/dataframe/tests/test_dataframe_utils.py
@@ -6,11 +6,6 @@ import pandas as pd
 import numpy as np
 
 
-def test_utils_is_dataframe_like():
-    test_utils_dataframe = pytest.importorskip('dask.dataframe.tests.test_utils_dataframe')
-    test_utils_dataframe.test_is_dataframe_like()
-
-
 def test_utils_get_base_frame_type_pandas():
     with pytest.raises(TypeError):
         get_base_frame_type("DataFrame", is_dataframe_like, None)

--- a/streamz/dataframe/tests/test_dataframes.py
+++ b/streamz/dataframe/tests/test_dataframes.py
@@ -69,8 +69,8 @@ def test_attributes():
     df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
     sdf = DataFrame(example=df)
 
-    assert 'x' in dir(sdf)
-    assert 'z' not in dir(sdf)
+    assert getattr(sdf,'x',-1) != -1
+    assert getattr(sdf,'z',-1) == -1
 
     sdf.x
     with pytest.raises(AttributeError):

--- a/streamz/tests/test_dask.py
+++ b/streamz/tests/test_dask.py
@@ -14,7 +14,7 @@ from distributed.utils import sync
 from distributed.utils_test import gen_cluster, inc, cluster, loop, slowinc  # noqa: F401
 
 
-@gen_cluster(client=True, check_new_threads=False)
+@gen_cluster(client=True)
 def test_map(c, s, a, b):
     source = Stream(asynchronous=True)
     futures = scatter(source).map(inc)


### PR DESCRIPTION
Some features are not yet available w.r.t. rolling objects in cudf. Will update the tests once the features are rolled out. 