### PR TITLE
fix stale docstring in `streamz.unique`.

### DIFF
--- a/streamz/core.py
+++ b/streamz/core.py
@@ -1184,13 +1184,13 @@ class unique(Stream):
     """ Avoid sending through repeated elements
 
     This deduplicates a stream so that only new elements pass through.
-    You can control how much of a history is stored with the ``history=``
-    parameter.  For example setting ``history=1`` avoids sending through
+    You can control how much of a history is stored with the ``maxsize=``
+    parameter.  For example setting ``maxsize=1`` avoids sending through
     elements when one is repeated right after the other.
 
     Parameters
     ----------
-    history : int or None, optional
+    maxsize: int or None, optional
         number of stored unique values to check against
     key : function, optional
         Function which returns a representation of the incoming data.
@@ -1205,7 +1205,7 @@ class unique(Stream):
     Examples
     --------
     >>> source = Stream()
-    >>> source.unique(history=1).sink(print)
+    >>> source.unique(maxsize=1).sink(print)
     >>> for x in [1, 1, 2, 2, 2, 1, 3]:
     ...     source.emit(x)
     1


### PR DESCRIPTION
I got a TypeError - unexpected keyword argument 'history' when following the document of [`streamz.unique`](https://streamz.readthedocs.io/en/latest/api.html#streamz.unique). [It seems the document is stale](https://github.com/python-streamz/streamz/pull/244/files#r281219507).

```
(venv) streamz [doc-fix●●] % python
Python 3.7.4 (default, Jul  9 2019, 18:13:23)
[Clang 10.0.1 (clang-1001.0.46.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from streamz import Stream
>>> source = Stream()
>>> source.unique(history=1).sink(print)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/private/tmp/streamz/streamz/core.py", line 238, in wrapped
    return func(*args, **kwargs)
  File "/private/tmp/streamz/streamz/core.py", line 1228, in __init__
    Stream.__init__(self, upstream, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'history'
>>> source.unique(maxsize=1).sink(print)
<sink: print>
```