### PR TITLE
Added to_kafka directly from a Dask worker

### DIFF
--- a/streamz/dask.py
+++ b/streamz/dask.py
@@ -2,13 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 from operator import getitem
 
+from dask.compatibility import apply
+from dask.distributed import get_worker
+from distributed.client import default_client
 from tornado import gen
 
-from dask.compatibility import apply
-from distributed.client import default_client
-
-from .core import Stream
 from . import core, sources
+from .core import Stream
 
 
 class DaskStream(Stream):
@@ -198,3 +198,48 @@ class filenames(DaskStream, sources.filenames):
 @DaskStream.register_api(staticmethod)
 class from_textfile(DaskStream, sources.from_textfile):
     pass
+
+
+@DaskStream.register_api()
+class to_kafka(DaskStream):
+    """ Write values to Kafka directly from the Dask worker
+
+    Parameters
+    ----------
+    topic : string
+        The topic which to write
+    producer_config : dict
+        Settings to set up the stream, see
+        https://docs.confluent.io/current/clients/confluent-kafka-python/#configuration
+        https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
+        Examples:
+        bootstrap.servers: Connection string (host:port) to Kafka
+
+    """
+    def __init__(self, upstream, topic, producer_config, **kwargs):
+        self.topic = topic
+        self.producer_config = producer_config
+
+        stream_name = kwargs.pop('stream_name', None)
+        DaskStream.__init__(self, upstream, stream_name=stream_name)
+
+    def update(self, x, who=None):
+
+        def get_producer(config):
+            w = get_worker()
+            if hasattr(w, 'producer'):
+                return w.producer
+
+            import confluent_kafka as ck
+            w.producer = getattr(ck, 'Producer')(config)
+            return w.producer
+
+        def produce(topic, value, producer_config):
+            producer = get_producer(producer_config)
+            producer.produce(topic, value)
+            producer.flush()
+            return value
+
+        client = default_client()
+        result = client.submit(produce, self.topic, x, self.producer_config)
+        self._emit(result)


### PR DESCRIPTION
Currently, we must `gather()` all the results from a Dask stream back to the master script and then push the results to Kafka. This removes all the benefits of parallel processing we get with Dask and Kafka.  It would be much more efficient if we could push data directly from the Dask workers into Kafka.

One issue I had getting this to work is that the Producer class from the Confluent Kafka Python library is not pickle-able. The workaround is to hide the Producer from the pickle function by creating it using "reflection" methods and create it on the worker side. However, I believe this adds a requirement that the confluent_kafka library must be installed on the worker.

Also, this implementation is serial, but Dask itself is parallel. 