### PR TITLE
networkx documentation

### DIFF
--- a/docs/source/core.rst
+++ b/docs/source/core.rst
@@ -156,7 +156,8 @@ Branching and Joining
    zip_latest
 
 You can branch multiple streams off of a single stream.  Elements that go into
-the input will pass through to both output streams.
+the input will pass through to both output streams.  Note: ``graphviz`` and
+``networkx`` need to be installed to visualize the stream graph.
 
 .. code-block:: python
 

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -450,7 +450,7 @@ class Stream(object):
     def visualize(self, filename='mystream.png', **kwargs):
         """Render the computation of this object's task graph using graphviz.
 
-        Requires ``graphviz`` to be installed.
+        Requires ``graphviz`` and ``networkx`` to be installed.
 
         Parameters
         ----------


### PR DESCRIPTION
updating documentation to include `networkx` as a dependency for `.visualize()`