### PR TITLE
Read key along with value for messages from Kafka

### DIFF
--- a/streamz/dataframe/tests/test_dataframes.py
+++ b/streamz/dataframe/tests/test_dataframes.py
@@ -388,7 +388,7 @@ def test_setitem_overwrites(stream):
     pytest.param({}, 'count', marks=pytest.mark.slow),
     ({'ddof': 0}, 'std'),
     pytest.param({'quantile': 0.5}, 'quantile', marks=pytest.mark.slow),
-    ({'arg': {'sum', 'min'}}, 'aggregate')
+    ({'arg': {'x':'sum'}}, 'aggregate')
 ])
 @pytest.mark.parametrize('window', [
     pytest.param(2, marks=pytest.mark.slow),

--- a/streamz/dataframe/tests/test_dataframes.py
+++ b/streamz/dataframe/tests/test_dataframes.py
@@ -387,8 +387,8 @@ def test_setitem_overwrites(stream):
     pytest.param({}, 'var', marks=pytest.mark.slow),
     pytest.param({}, 'count', marks=pytest.mark.slow),
     ({'ddof': 0}, 'std'),
-    pytest.param({'quantile': 0.5}, 'quantile', marks=pytest.mark.slow)
-    # ({'arg': {'A': 'sum', 'B': 'min'}}, 'aggregate') -- Deprecated usage with Pandas1.0
+    pytest.param({'quantile': 0.5}, 'quantile', marks=pytest.mark.slow),
+    ({'arg': {'sum', 'min'}}, 'aggregate')
 ])
 @pytest.mark.parametrize('window', [
     pytest.param(2, marks=pytest.mark.slow),

--- a/streamz/dataframe/tests/test_dataframes.py
+++ b/streamz/dataframe/tests/test_dataframes.py
@@ -407,7 +407,7 @@ def test_setitem_overwrites(stream):
 ])
 def test_rolling_count_aggregations(op, window, m, pre_get, post_get, kwargs,
         stream):
-    index = pd.DatetimeIndex(start='2000-01-01', end='2000-01-03', freq='1h')
+    index = pd.date_range(start='2000-01-01', end='2000-01-03', freq='1h')
     df = pd.DataFrame({'x': np.arange(len(index))}, index=index)
 
     expected = getattr(post_get(pre_get(df).rolling(window)), op)(**kwargs)
@@ -725,7 +725,7 @@ def test_windowing_n(func, n, getter):
                                      lambda g: g[['x']],
                                      lambda g: g[['x', 'y']]])
 def test_groupby_windowing_value(func, value, getter, grouper, indexer):
-    index = pd.DatetimeIndex(start='2000-01-01', end='2000-01-03', freq='1h')
+    index = pd.date_range(start='2000-01-01', end='2000-01-03', freq='1h')
     df = pd.DataFrame({'x': np.arange(len(index), dtype=float),
                        'y': np.arange(len(index), dtype=float) % 2},
                       index=index)

--- a/streamz/dataframe/tests/test_dataframes.py
+++ b/streamz/dataframe/tests/test_dataframes.py
@@ -388,7 +388,7 @@ def test_setitem_overwrites(stream):
     pytest.param({}, 'count', marks=pytest.mark.slow),
     ({'ddof': 0}, 'std'),
     pytest.param({'quantile': 0.5}, 'quantile', marks=pytest.mark.slow)
-#     ({'arg': {'x':'sum'}}, 'aggregate') -- deprecated with Pandas1.0
+    # ({'arg': {'A':'sum', 'B':'min'}, 'aggregate') -- deprecated with Pandas1.0
 ])
 @pytest.mark.parametrize('window', [
     pytest.param(2, marks=pytest.mark.slow),

--- a/streamz/dataframe/tests/test_dataframes.py
+++ b/streamz/dataframe/tests/test_dataframes.py
@@ -387,8 +387,8 @@ def test_setitem_overwrites(stream):
     pytest.param({}, 'var', marks=pytest.mark.slow),
     pytest.param({}, 'count', marks=pytest.mark.slow),
     ({'ddof': 0}, 'std'),
-    pytest.param({'quantile': 0.5}, 'quantile', marks=pytest.mark.slow),
-    ({'arg': {'x':'sum'}}, 'aggregate')
+    pytest.param({'quantile': 0.5}, 'quantile', marks=pytest.mark.slow)
+#     ({'arg': {'x':'sum'}}, 'aggregate') -- deprecated with Pandas1.0
 ])
 @pytest.mark.parametrize('window', [
     pytest.param(2, marks=pytest.mark.slow),

--- a/streamz/dataframe/tests/test_dataframes.py
+++ b/streamz/dataframe/tests/test_dataframes.py
@@ -387,8 +387,8 @@ def test_setitem_overwrites(stream):
     pytest.param({}, 'var', marks=pytest.mark.slow),
     pytest.param({}, 'count', marks=pytest.mark.slow),
     ({'ddof': 0}, 'std'),
-    pytest.param({'quantile': 0.5}, 'quantile', marks=pytest.mark.slow),
-    ({'arg': {'A': 'sum', 'B': 'min'}}, 'aggregate')
+    pytest.param({'quantile': 0.5}, 'quantile', marks=pytest.mark.slow)
+    # ({'arg': {'A': 'sum', 'B': 'min'}}, 'aggregate') -- Deprecated usage with Pandas1.0
 ])
 @pytest.mark.parametrize('window', [
     pytest.param(2, marks=pytest.mark.slow),

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -575,7 +575,7 @@ def get_message_batch(kafka_params, topic, partition, low, high, timeout=None):
             msg = consumer.poll(0)
             if msg and msg.value() and msg.error() is None:
                 if high >= msg.offset():
-                    out.append(msg.value())
+                    out.append(msg.key(), msg.value())
                 if high <= msg.offset():
                     break
             else:

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -575,7 +575,7 @@ def get_message_batch(kafka_params, topic, partition, low, high, timeout=None):
             msg = consumer.poll(0)
             if msg and msg.value() and msg.error() is None:
                 if high >= msg.offset():
-                    out.append(msg.key(), msg.value())
+                    out.append((msg.key(), msg.value()))
                 if high <= msg.offset():
                     break
             else:

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -575,7 +575,7 @@ def get_message_batch(kafka_params, topic, partition, low, high, timeout=None):
             msg = consumer.poll(0)
             if msg and msg.value() and msg.error() is None:
                 if high >= msg.offset():
-                    out.append((msg.key(), msg.value()))
+                    out.append({'key':msg.key(), 'value':msg.value()})
                 if high <= msg.offset():
                     break
             else:

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -509,7 +509,7 @@ class FromKafkaBatched(Stream):
 @Stream.register_api(staticmethod)
 def from_kafka_batched(topic, consumer_params, poll_interval='1s',
                        npartitions=1, start=False, dask=False, keys=False, **kwargs):
-    """ Get messages from Kafka in batches
+    """ Get messages and keys (optional) from Kafka in batches
 
     Uses the confluent-kafka library,
     https://docs.confluent.io/current/clients/confluent-kafka-python/
@@ -536,6 +536,9 @@ def from_kafka_batched(topic, consumer_params, poll_interval='1s',
         Number of partitions in the topic
     start: bool (False)
         Whether to start polling upon instantiation
+    keys: bool (False)
+        Whether to extract keys along with the messages. If True, this will yield each message as a dict:
+        {'key':msg.key(), 'value':msg.value()}
 
     Examples
     --------

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -560,7 +560,7 @@ def from_kafka_batched(topic, consumer_params, poll_interval='1s',
 
 
 def get_message_batch(kafka_params, topic, partition, low, high, timeout=None):
-    """Fetch a batch of kafka messages in given topic/partition
+    """Fetch a batch of kafka messages (keys & values) in given topic/partition
 
     This will block until messages are available, or timeout is reached.
     """

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -453,12 +453,13 @@ class from_kafka(Source):
 class FromKafkaBatched(Stream):
     """Base class for both local and cluster-based batched kafka processing"""
     def __init__(self, topic, consumer_params, poll_interval='1s',
-                 npartitions=1, **kwargs):
+                 npartitions=1, keys=False, **kwargs):
         self.consumer_params = consumer_params
         self.topic = topic
         self.npartitions = npartitions
         self.positions = [0] * npartitions
         self.poll_interval = convert_interval(poll_interval)
+        self.keys = keys
         self.stopped = True
 
         super(FromKafkaBatched, self).__init__(ensure_io_loop=True, **kwargs)
@@ -481,7 +482,7 @@ class FromKafkaBatched(Stream):
                     lowest = max(current_position, low)
                     if high > lowest:
                         out.append((self.consumer_params, self.topic, partition,
-                                    lowest, high - 1))
+                                    self.keys, lowest, high - 1))
                         self.positions[partition] = high
 
                 for part in out:
@@ -507,7 +508,7 @@ class FromKafkaBatched(Stream):
 
 @Stream.register_api(staticmethod)
 def from_kafka_batched(topic, consumer_params, poll_interval='1s',
-                       npartitions=1, start=False, dask=False, **kwargs):
+                       npartitions=1, start=False, dask=False, keys=False, **kwargs):
     """ Get messages from Kafka in batches
 
     Uses the confluent-kafka library,
@@ -549,7 +550,8 @@ def from_kafka_batched(topic, consumer_params, poll_interval='1s',
         kwargs['loop'] = default_client().loop
     source = FromKafkaBatched(topic, consumer_params,
                               poll_interval=poll_interval,
-                              npartitions=npartitions, **kwargs)
+                              npartitions=npartitions, keys=keys,
+                              **kwargs)
     if dask:
         source = source.scatter()
 
@@ -559,7 +561,7 @@ def from_kafka_batched(topic, consumer_params, poll_interval='1s',
     return source.starmap(get_message_batch)
 
 
-def get_message_batch(kafka_params, topic, partition, low, high, timeout=None):
+def get_message_batch(kafka_params, topic, partition, keys, low, high, timeout=None):
     """Fetch a batch of kafka messages (keys & values) in given topic/partition
 
     This will block until messages are available, or timeout is reached.
@@ -575,7 +577,10 @@ def get_message_batch(kafka_params, topic, partition, low, high, timeout=None):
             msg = consumer.poll(0)
             if msg and msg.value() and msg.error() is None:
                 if high >= msg.offset():
-                    out.append({'key':msg.key(), 'value':msg.value()})
+                    if keys:
+                        out.append({'key':msg.key(), 'value':msg.value()})
+                    else:
+                        out.append(msg.value())
                 if high <= msg.offset():
                     break
             else:

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -196,7 +196,7 @@ def test_kafka_batch():
             kafka.produce(TOPIC, b'value-%d' % i)
         kafka.flush()
         # out may still be empty or first item of out may be []
-        wait_for(lambda: any(out) and out[-1][-1] == b'value-9', 10, period=0.2)
+        wait_for(lambda: any(out) and out[-1][-1][1] == b'value-9', 10, period=0.2)
         stream.upstream.stopped = True
 
 
@@ -217,5 +217,5 @@ def test_kafka_dask_batch(c, s, w1, w2):
             kafka.produce(TOPIC, b'value-%d' % i)
         kafka.flush()
         yield await_for(lambda: any(out), 10, period=0.2)
-        assert b'value-1' in out[0]
+        assert (None, b'value-1') in out[0]
         stream.upstream.stopped = True

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -193,10 +193,11 @@ def test_kafka_batch():
         out = stream.sink_to_list()
         stream.start()
         for i in range(10):
-            kafka.produce(TOPIC, b'value-%d' % i)
+            kafka.produce(TOPIC, b'value-%d' % i, b'%d' % i)
         kafka.flush()
         # out may still be empty or first item of out may be []
-        wait_for(lambda: any(out) and out[-1][-1][1] == b'value-9', 10, period=0.2)
+        wait_for(lambda: any(out) and out[-1][-1]['value'] == b'value-9', 10, period=0.2)
+        assert out[-1][-1]['key'] == b'9'
         stream.upstream.stopped = True
 
 
@@ -217,5 +218,5 @@ def test_kafka_dask_batch(c, s, w1, w2):
             kafka.produce(TOPIC, b'value-%d' % i)
         kafka.flush()
         yield await_for(lambda: any(out), 10, period=0.2)
-        assert (None, b'value-1') in out[0]
+        assert {'key':None, 'value':b'value-1'} in out[0]
         stream.upstream.stopped = True

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -189,7 +189,7 @@ def test_kafka_batch():
             'group.id': 'streamz-test%i' % j}
     with kafka_service() as kafka:
         kafka, TOPIC = kafka
-        stream = Stream.from_kafka_batched(TOPIC, ARGS)
+        stream = Stream.from_kafka_batched(TOPIC, ARGS, keys=True)
         out = stream.sink_to_list()
         stream.start()
         for i in range(10):
@@ -208,8 +208,8 @@ def test_kafka_dask_batch(c, s, w1, w2):
             'group.id': 'streamz-test%i' % j}
     with kafka_service() as kafka:
         kafka, TOPIC = kafka
-        stream = Stream.from_kafka_batched(TOPIC, ARGS, asynchronous=True,
-                                           dask=True)
+        stream = Stream.from_kafka_batched(TOPIC, ARGS, keys=True,
+                                           asynchronous=True, dask=True)
         out = stream.gather().sink_to_list()
         stream.start()
         yield gen.sleep(5)  # this frees the loop while dask workers report in


### PR DESCRIPTION
Most streaming data processors like Spark read both the key and value for Kafka messages. Most streaming jobs have Kafka message keys as Null, but some of them which need custom load balancing/data ordering across partitions, work more efficiently with keys.