### PR TITLE
Added reference counting and Kafka checkpointing

### DIFF
--- a/streamz/core.py
+++ b/streamz/core.py
@@ -57,6 +57,26 @@ def identity(x):
     return x
 
 
+class RefCounter:
+    def __init__(self, initial=0, cb=None, loop=None):
+        self.loop = loop if loop else get_io_loop()
+        self.count = initial
+        self.cb = cb
+
+    def retain(self, x=1):
+        self.count += x
+
+    def release(self, x=1):
+        self.count -= x
+        if self.count <= 0 and self.cb:
+            self.loop.add_callback(self.cb)
+
+    def __str__(self):
+        return '<RefCounter count={}>'.format(self.count)
+
+    __repr__ = __str__
+
+
 class Stream(object):
     """ A Stream is an infinite sequence of data
 
@@ -319,18 +339,35 @@ class Stream(object):
 
         return output._ipython_display_(**kwargs)
 
-    def _emit(self, x):
+    def _emit(self, x, metadata=None):
+        if metadata is None:
+            metadata = {}
+
+        refs = []
+        if 'refs' in metadata:
+            refs = metadata['refs']
+            if not isinstance(refs, list):
+                refs = [refs]
+
         result = []
-        for downstream in list(self.downstreams):
-            r = downstream.update(x, who=self)
+        downstreams = list(self.downstreams)
+        for ref in refs:
+            ref.retain(len(downstreams))
+
+        for downstream in downstreams:
+            r = downstream.update(x, who=self, metadata=metadata)
+
             if type(r) is list:
                 result.extend(r)
             else:
                 result.append(r)
 
+            for ref in refs:
+                ref.release()
+
         return [element for element in result if element is not None]
 
-    def emit(self, x, asynchronous=False):
+    def emit(self, x, asynchronous=False, metadata=None):
         """ Push data into the stream at this point
 
         This is typically done only at source Streams but can theortically be
@@ -341,7 +378,7 @@ class Stream(object):
             if not ts_async:
                 thread_state.asynchronous = True
             try:
-                result = self._emit(x)
+                result = self._emit(x, metadata=metadata)
                 if self.loop:
                     return gen.convert_yielded(result)
             finally:
@@ -358,8 +395,8 @@ class Stream(object):
                 raise gen.Return(result)
             sync(self.loop, _)
 
-    def update(self, x, who=None):
-        self._emit(x)
+    def update(self, x, who=None, metadata=None):
+        self._emit(x, metadata=metadata)
 
     def gather(self):
         """ This is a no-op for core streamz
@@ -497,6 +534,28 @@ class Stream(object):
         from .batch import Batch
         return Batch(stream=self, **kwargs)
 
+    def _retain_refs(self, metadata):
+        if not isinstance(metadata, list):
+            metadata = [metadata]
+        for m in metadata:
+            if m and 'refs' in m:
+                refs = m['refs']
+                if not isinstance(refs, list):
+                    refs = [refs]
+                for ref in refs:
+                    ref.retain(1)
+
+    def _release_refs(self, metadata):
+        if not isinstance(metadata, list):
+            metadata = [metadata]
+        for m in metadata:
+            if m and 'refs' in m:
+                refs = m['refs']
+                if not isinstance(refs, list):
+                    refs = [refs]
+                for ref in refs:
+                    ref.release(1)
+
 
 @Stream.register_api()
 class sink(Stream):
@@ -532,7 +591,7 @@ class sink(Stream):
         Stream.__init__(self, upstream, stream_name=stream_name)
         _global_sinks.add(self)
 
-    def update(self, x, who=None):
+    def update(self, x, who=None, metadata=None):
         result = self.func(x, *self.args, **self.kwargs)
         if gen.isawaitable(result):
             return result
@@ -573,14 +632,14 @@ class map(Stream):
 
         Stream.__init__(self, upstream, stream_name=stream_name)
 
-    def update(self, x, who=None):
+    def update(self, x, who=None, metadata=None):
         try:
             result = self.func(x, *self.args, **self.kwargs)
         except Exception as e:
             logger.exception(e)
             raise
         else:
-            return self._emit(result)
+            return self._emit(result, metadata=metadata)
 
 
 @Stream.register_api()
@@ -618,7 +677,7 @@ class starmap(Stream):
 
         Stream.__init__(self, upstream, stream_name=stream_name)
 
-    def update(self, x, who=None):
+    def update(self, x, who=None, metadata=None):
         y = x + self.args
         try:
             result = self.func(*y, **self.kwargs)
@@ -626,7 +685,7 @@ class starmap(Stream):
             logger.exception(e)
             raise
         else:
-            return self._emit(result)
+            return self._emit(result, metadata=metadata)
 
 
 def _truthy(x):
@@ -668,9 +727,9 @@ class filter(Stream):
 
         Stream.__init__(self, upstream, stream_name=stream_name)
 
-    def update(self, x, who=None):
+    def update(self, x, who=None, metadata=None):
         if self.predicate(x, *self.args, **self.kwargs):
-            return self._emit(x)
+            return self._emit(x, metadata=metadata)
 
 
 @Stream.register_api()
@@ -749,10 +808,10 @@ class accumulate(Stream):
         stream_name = kwargs.pop('stream_name', None)
         Stream.__init__(self, upstream, stream_name=stream_name)
 
-    def update(self, x, who=None):
+    def update(self, x, who=None, metadata=None):
         if self.state is no_default:
             self.state = x
-            return self._emit(x)
+            return self._emit(x, metadata=metadata)
         else:
             try:
                 result = self.func(self.state, x, **self.kwargs)
@@ -764,7 +823,7 @@ class accumulate(Stream):
             else:
                 state = result
             self.state = state
-            return self._emit(result)
+            return self._emit(result, metadata=metadata)
 
 
 @Stream.register_api()
@@ -803,9 +862,9 @@ class slice(Stream):
         Stream.__init__(self, upstream, stream_name=stream_name)
         self._check_end()
 
-    def update(self, x, who=None):
+    def update(self, x, who=None, metadata=None):
         if self.state >= self.star and self.state % self.step == 0:
-            self.emit(x)
+            self.emit(x, metadata=metadata)
         self.state += 1
         self._check_end()
 
@@ -835,13 +894,23 @@ class partition(Stream):
     def __init__(self, upstream, n, **kwargs):
         self.n = n
         self.buffer = []
+        self.metadata_buffer = []
         Stream.__init__(self, upstream, **kwargs)
 
-    def update(self, x, who=None):
+    def update(self, x, who=None, metadata=None):
+        self._retain_refs(metadata)
         self.buffer.append(x)
+        if isinstance(metadata, list):
+            self.metadata_buffer.extend(metadata)
+        else:
+            self.metadata_buffer.append(metadata)
         if len(self.buffer) == self.n:
             result, self.buffer = self.buffer, []
-            return self._emit(tuple(result))
+            metadata_result, self.metadata_buffer = self.metadata_buffer, []
+            ret = self._emit(tuple(result), list(metadata_result))
+            for metadata in metadata_result:
+                self._release_refs(metadata)
+            return ret
         else:
             return []
 
@@ -875,13 +944,23 @@ class sliding_window(Stream):
     def __init__(self, upstream, n, return_partial=True, **kwargs):
         self.n = n
         self.buffer = deque(maxlen=n)
+        self.metadata_buffer = deque(maxlen=n)
         self.partial = return_partial
         Stream.__init__(self, upstream, **kwargs)
 
-    def update(self, x, who=None):
+    def update(self, x, who=None, metadata=None):
+        self._retain_refs(metadata)
         self.buffer.append(x)
+        if not isinstance(metadata, list):
+            metadata = [metadata]
+        self.metadata_buffer.append(metadata)
         if self.partial or len(self.buffer) == self.n:
-            return self._emit(tuple(self.buffer))
+            flat_metadata = [m for l in self.metadata_buffer for m in l]
+            ret = self._emit(tuple(self.buffer), flat_metadata)
+            if len(self.metadata_buffer) == self.n:
+                completed = self.metadata_buffer.popleft()
+                self._release_refs(completed)
+            return ret
         else:
             return []
 
@@ -906,21 +985,27 @@ class timed_window(Stream):
     def __init__(self, upstream, interval, **kwargs):
         self.interval = convert_interval(interval)
         self.buffer = []
+        self.metadata_buffer = []
         self.last = gen.moment
 
         Stream.__init__(self, upstream, ensure_io_loop=True, **kwargs)
 
         self.loop.add_callback(self.cb)
 
-    def update(self, x, who=None):
+    def update(self, x, who=None, metadata=None):
         self.buffer.append(x)
+        self._retain_refs(metadata)
+        self.metadata_buffer.append(metadata)
         return self.last
 
     @gen.coroutine
     def cb(self):
         while True:
             L, self.buffer = self.buffer, []
-            self.last = self._emit(L)
+            metadata, self.metadata_buffer = self.metadata_buffer, []
+            self.last = self._emit(L, metadata)
+            for m in metadata:
+                self._release_refs(m)
             yield self.last
             yield gen.sleep(self.interval)
 
@@ -942,14 +1027,16 @@ class delay(Stream):
     def cb(self):
         while True:
             last = time()
-            x = yield self.queue.get()
-            yield self._emit(x)
+            x, metadata = yield self.queue.get()
+            yield self._emit(x, metadata=metadata)
+            self._release_refs(metadata)
             duration = self.interval - (time() - last)
             if duration > 0:
                 yield gen.sleep(duration)
 
-    def update(self, x, who=None):
-        return self.queue.put(x)
+    def update(self, x, who=None, metadata=None):
+        self._retain_refs(metadata)
+        return self.queue.put((x, metadata))
 
 
 @Stream.register_api()
@@ -973,13 +1060,13 @@ class rate_limit(Stream):
         Stream.__init__(self, upstream, ensure_io_loop=True, **kwargs)
 
     @gen.coroutine
-    def update(self, x, who=None):
+    def update(self, x, who=None, metadata=None):
         now = time()
         old_next = self.next
         self.next = max(now, self.next) + self.interval
         if now < old_next:
             yield gen.sleep(old_next - now)
-        yield self._emit(x)
+        yield self._emit(x, metadata=metadata)
 
 
 @Stream.register_api()
@@ -999,14 +1086,16 @@ class buffer(Stream):
 
         self.loop.add_callback(self.cb)
 
-    def update(self, x, who=None):
-        return self.queue.put(x)
+    def update(self, x, who=None, metadata=None):
+        self._retain_refs(metadata)
+        return self.queue.put((x, metadata))
 
     @gen.coroutine
     def cb(self):
         while True:
-            x = yield self.queue.get()
-            yield self._emit(x)
+            x, metadata = yield self.queue.get()
+            yield self._emit(x, metadata=metadata)
+            self._release_refs(metadata)
 
 
 @Stream.register_api()
@@ -1061,17 +1150,22 @@ class zip(Stream):
 
         return tuple(out)
 
-    def update(self, x, who=None):
+    def update(self, x, who=None, metadata=None):
+        self._retain_refs(metadata)
         L = self.buffers[who]  # get buffer for stream
-        L.append(x)
+        L.append((x, metadata))
         if len(L) == 1 and all(self.buffers.values()):
-            tup = tuple(self.buffers[up][0] for up in self.upstreams)
+            vals = [self.buffers[up][0] for up in self.upstreams]
+            tup, md = __builtins__['zip'](*vals)
             for buf in self.buffers.values():
                 buf.popleft()
             self.condition.notify_all()
             if self.literals:
                 tup = self.pack_literals(tup)
-            return self._emit(tup)
+            ret = self._emit(tup, list(md))
+            for m in md:
+                self._release_refs(m)
+            return ret
         elif len(L) > self.maxsize:
             return self.condition.wait()
 
@@ -1101,6 +1195,7 @@ class combine_latest(Stream):
         self._initial_emit_on = emit_on
 
         self.last = [None for _ in upstreams]
+        self.metadata = [None for _ in upstreams]
         self.missing = set(upstreams)
         if emit_on is not None:
             if not isinstance(emit_on, Iterable):
@@ -1115,6 +1210,7 @@ class combine_latest(Stream):
     def _add_upstream(self, upstream):
         # Override method to handle setup of last and missing for new stream
         self.last.append(None)
+        self.metadata.append(None)
         self.missing.update([upstream])
         super(combine_latest, self)._add_upstream(upstream)
         if self._initial_emit_on is None:
@@ -1131,19 +1227,26 @@ class combine_latest(Stream):
                                "``node.emit_on=tuple(node.upstreams)`` to "
                                "emit on all incoming data")
         self.last.pop(self.upstreams.index(upstream))
+        self.metadata.pop(self.upstreams.index(upstream))
         self.missing.remove(upstream)
         super(combine_latest, self)._remove_upstream(upstream)
         if self._initial_emit_on is None:
             self.emit_on = self.upstreams
 
-    def update(self, x, who=None):
+    def update(self, x, who=None, metadata=None):
+        self._retain_refs(metadata)
+        idx = self.upstreams.index(who)
+        if idx in self.metadata:
+            self._release_refs(self.metadata[idx])
+        self.metadata[idx] = metadata
+
         if self.missing and who in self.missing:
             self.missing.remove(who)
 
-        self.last[self.upstreams.index(who)] = x
+        self.last[idx] = x
         if not self.missing and who in self.emit_on:
             tup = tuple(self.last)
-            return self._emit(tup)
+            return self._emit(tup, self.metadata)
 
 
 @Stream.register_api()
@@ -1168,10 +1271,13 @@ class flatten(Stream):
     --------
     partition
     """
-    def update(self, x, who=None):
+    def update(self, x, who=None, metadata=None):
         L = []
-        for item in x:
-            y = self._emit(item)
+        for i, item in enumerate(x):
+            if i == len(x) - 1:
+                y = self._emit(item, metadata=metadata)
+            else:
+                y = self._emit(item)
             if type(y) is list:
                 L.extend(y)
             else:
@@ -1227,7 +1333,7 @@ class unique(Stream):
 
         Stream.__init__(self, upstream, **kwargs)
 
-    def update(self, x, who=None):
+    def update(self, x, who=None, metadata=None):
         y = self.key(x)
         emit = True
         if isinstance(self.seen, list):
@@ -1238,7 +1344,7 @@ class unique(Stream):
             if self.maxsize:
                 del self.seen[self.maxsize:]
             if emit:
-                return self._emit(x)
+                return self._emit(x, metadata=metadata)
         else:
             if self.seen.get(y, '~~not_seen~~') == '~~not_seen~~':
                 self.seen[y] = 1
@@ -1261,8 +1367,8 @@ class union(Stream):
     def __init__(self, *upstreams, **kwargs):
         super(union, self).__init__(upstreams=upstreams, **kwargs)
 
-    def update(self, x, who=None):
-        return self._emit(x)
+    def update(self, x, who=None, metadata=None):
+        return self._emit(x, metadata=metadata)
 
 
 @Stream.register_api()
@@ -1296,11 +1402,12 @@ class pluck(Stream):
         self.pick = pick
         super(pluck, self).__init__(upstream, **kwargs)
 
-    def update(self, x, who=None):
+    def update(self, x, who=None, metadata=None):
         if isinstance(self.pick, list):
-            return self._emit(tuple([x[ind] for ind in self.pick]))
+            return self._emit(tuple([x[ind] for ind in self.pick]),
+                              metadata=metadata)
         else:
-            return self._emit(x[self.pick])
+            return self._emit(x[self.pick], metadata=metadata)
 
 
 @Stream.register_api()
@@ -1321,20 +1428,33 @@ class collect(Stream):
     ...
     [1, 2]
     """
-    def __init__(self, upstream, cache=None, **kwargs):
+    def __init__(self, upstream, cache=None, metadata_cache=None, **kwargs):
         if cache is None:
             cache = deque()
         self.cache = cache
 
+        if metadata_cache is None:
+            metadata_cache = deque()
+        self.metadata_cache = metadata_cache
+
         Stream.__init__(self, upstream, **kwargs)
 
-    def update(self, x, who=None):
+    def update(self, x, who=None, metadata=None):
+        self._retain_refs(metadata)
         self.cache.append(x)
+        if metadata:
+            if isinstance(metadata, list):
+                self.metadata_cache.extend(metadata)
+            else:
+                self.metadata_cache.append(metadata)
 
     def flush(self, _=None):
         out = tuple(self.cache)
-        self._emit(out)
+        metadata = list(self.metadata_cache)
+        self._emit(out, metadata)
+        self._release_refs(metadata)
         self.cache.clear()
+        self.metadata_cache.clear()
 
 
 @Stream.register_api()
@@ -1356,16 +1476,20 @@ class zip_latest(Stream):
     def __init__(self, lossless, *upstreams, **kwargs):
         upstreams = (lossless,) + upstreams
         self.last = [None for _ in upstreams]
+        self.metadata = [None for _ in upstreams]
         self.missing = set(upstreams)
         self.lossless = lossless
         self.lossless_buffer = deque()
         Stream.__init__(self, upstreams=upstreams, **kwargs)
 
-    def update(self, x, who=None):
+    def update(self, x, who=None, metadata=None):
+        self._retain_refs(metadata)
         idx = self.upstreams.index(who)
         if who is self.lossless:
-            self.lossless_buffer.append(x)
-
+            self.lossless_buffer.append((x, metadata))
+        elif self.metadata[idx]:
+            self._release_refs(self.metadata[idx])
+        self.metadata[idx] = metadata
         self.last[idx] = x
         if self.missing and who in self.missing:
             self.missing.remove(who)
@@ -1373,8 +1497,9 @@ class zip_latest(Stream):
         if not self.missing:
             L = []
             while self.lossless_buffer:
-                self.last[0] = self.lossless_buffer.popleft()
-                L.append(self._emit(tuple(self.last)))
+                self.last[0], self.metadata[0] = self.lossless_buffer.popleft()
+                L.append(self._emit(tuple(self.last), metadata=self.metadata))
+                self._release_refs(self.metadata[0])
             return L
 
 
@@ -1397,13 +1522,18 @@ class latest(Stream):
     def __init__(self, upstream, **kwargs):
         self.condition = Condition()
         self.next = []
+        self.next_metadata = None
 
         Stream.__init__(self, upstream, ensure_io_loop=True, **kwargs)
 
         self.loop.add_callback(self.cb)
 
-    def update(self, x, who=None):
+    def update(self, x, who=None, metadata=None):
+        self._release_refs(self.next_metadata)
+        self._retain_refs(metadata)
+
         self.next = [x]
+        self.next_metadata = metadata
         self.loop.add_callback(self.condition.notify)
 
     @gen.coroutine
@@ -1411,7 +1541,7 @@ class latest(Stream):
         while True:
             yield self.condition.wait()
             [x] = self.next
-            yield self._emit(x)
+            yield self._emit(x, self.next_metadata)
 
 
 @Stream.register_api()
@@ -1463,7 +1593,7 @@ class to_kafka(Stream):
             self.producer.poll(0)
             yield gen.sleep(self.polltime)
 
-    def update(self, x, who=None):
+    def update(self, x, who=None, metadata=None):
         future = gen.Future()
         self.futures.append(future)
 

--- a/streamz/dataframe/tests/test_dataframes.py
+++ b/streamz/dataframe/tests/test_dataframes.py
@@ -387,8 +387,8 @@ def test_setitem_overwrites(stream):
     pytest.param({}, 'var', marks=pytest.mark.slow),
     pytest.param({}, 'count', marks=pytest.mark.slow),
     ({'ddof': 0}, 'std'),
-    pytest.param({'quantile': 0.5}, 'quantile', marks=pytest.mark.slow),
-    ({'arg': {'A': 'sum', 'B': 'min'}}, 'aggregate')
+    pytest.param({'quantile': 0.5}, 'quantile', marks=pytest.mark.slow)
+    # ({'arg': {'A':'sum', 'B':'min'}, 'aggregate') -- deprecated with Pandas1.0
 ])
 @pytest.mark.parametrize('window', [
     pytest.param(2, marks=pytest.mark.slow),
@@ -407,7 +407,7 @@ def test_setitem_overwrites(stream):
 ])
 def test_rolling_count_aggregations(op, window, m, pre_get, post_get, kwargs,
         stream):
-    index = pd.DatetimeIndex(start='2000-01-01', end='2000-01-03', freq='1h')
+    index = pd.date_range(start='2000-01-01', end='2000-01-03', freq='1h')
     df = pd.DataFrame({'x': np.arange(len(index))}, index=index)
 
     expected = getattr(post_get(pre_get(df).rolling(window)), op)(**kwargs)
@@ -725,7 +725,7 @@ def test_windowing_n(func, n, getter):
                                      lambda g: g[['x']],
                                      lambda g: g[['x', 'y']]])
 def test_groupby_windowing_value(func, value, getter, grouper, indexer):
-    index = pd.DatetimeIndex(start='2000-01-01', end='2000-01-03', freq='1h')
+    index = pd.date_range(start='2000-01-01', end='2000-01-03', freq='1h')
     df = pd.DataFrame({'x': np.arange(len(index), dtype=float),
                        'y': np.arange(len(index), dtype=float) % 2},
                       index=index)

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -5,7 +5,7 @@ import time
 import tornado.ioloop
 from tornado import gen
 
-from .core import Stream, convert_interval
+from .core import Stream, convert_interval, RefCounter
 
 
 def PeriodicCallback(callback, callback_time, asynchronous=False, **kwargs):
@@ -453,12 +453,13 @@ class from_kafka(Source):
 class FromKafkaBatched(Stream):
     """Base class for both local and cluster-based batched kafka processing"""
     def __init__(self, topic, consumer_params, poll_interval='1s',
-                 npartitions=1, **kwargs):
+                 npartitions=1, keys=False, **kwargs):
         self.consumer_params = consumer_params
         self.topic = topic
         self.npartitions = npartitions
         self.positions = [0] * npartitions
         self.poll_interval = convert_interval(poll_interval)
+        self.keys = keys
         self.stopped = True
 
         super(FromKafkaBatched, self).__init__(ensure_io_loop=True, **kwargs)
@@ -466,6 +467,30 @@ class FromKafkaBatched(Stream):
     @gen.coroutine
     def poll_kafka(self):
         import confluent_kafka as ck
+
+        def commit(_part):
+            topic, part_no, _, _, offset = _part[1:]
+            _tp = ck.TopicPartition(topic, part_no, offset + 1)
+            self.consumer.commit(offsets=[_tp], asynchronous=True)
+
+        @gen.coroutine
+        def checkpoint_emit(_part):
+            ref = RefCounter(cb=lambda: commit(_part))
+            yield self._emit(_part, metadata={'refs': ref})
+
+        tps = []
+        for partition in range(self.npartitions):
+            tps.append(ck.TopicPartition(self.topic, partition))
+
+        while True:
+            try:
+                committed = self.consumer.committed(tps, timeout=1)
+            except ck.KafkaException:
+                pass
+            else:
+                for tp in committed:
+                    self.positions[tp.partition] = tp.offset
+                break
 
         try:
             while not self.stopped:
@@ -481,11 +506,11 @@ class FromKafkaBatched(Stream):
                     lowest = max(current_position, low)
                     if high > lowest:
                         out.append((self.consumer_params, self.topic, partition,
-                                    lowest, high - 1))
+                                    self.keys, lowest, high - 1))
                         self.positions[partition] = high
 
                 for part in out:
-                    yield self._emit(part)
+                    self.loop.add_callback(checkpoint_emit, part)
 
                 else:
                     yield gen.sleep(self.poll_interval)
@@ -507,8 +532,8 @@ class FromKafkaBatched(Stream):
 
 @Stream.register_api(staticmethod)
 def from_kafka_batched(topic, consumer_params, poll_interval='1s',
-                       npartitions=1, start=False, dask=False, **kwargs):
-    """ Get messages from Kafka in batches
+                       npartitions=1, start=False, dask=False, keys=False, **kwargs):
+    """ Get messages and keys (optional) from Kafka in batches
 
     Uses the confluent-kafka library,
     https://docs.confluent.io/current/clients/confluent-kafka-python/
@@ -535,6 +560,9 @@ def from_kafka_batched(topic, consumer_params, poll_interval='1s',
         Number of partitions in the topic
     start: bool (False)
         Whether to start polling upon instantiation
+    keys: bool (False)
+        Whether to extract keys along with the messages. If True, this will yield each message as a dict:
+        {'key':msg.key(), 'value':msg.value()}
 
     Examples
     --------
@@ -549,7 +577,8 @@ def from_kafka_batched(topic, consumer_params, poll_interval='1s',
         kwargs['loop'] = default_client().loop
     source = FromKafkaBatched(topic, consumer_params,
                               poll_interval=poll_interval,
-                              npartitions=npartitions, **kwargs)
+                              npartitions=npartitions, keys=keys,
+                              **kwargs)
     if dask:
         source = source.scatter()
 
@@ -559,8 +588,8 @@ def from_kafka_batched(topic, consumer_params, poll_interval='1s',
     return source.starmap(get_message_batch)
 
 
-def get_message_batch(kafka_params, topic, partition, low, high, timeout=None):
-    """Fetch a batch of kafka messages in given topic/partition
+def get_message_batch(kafka_params, topic, partition, keys, low, high, timeout=None):
+    """Fetch a batch of kafka messages (keys & values) in given topic/partition
 
     This will block until messages are available, or timeout is reached.
     """
@@ -575,7 +604,10 @@ def get_message_batch(kafka_params, topic, partition, low, high, timeout=None):
             msg = consumer.poll(0)
             if msg and msg.value() and msg.error() is None:
                 if high >= msg.offset():
-                    out.append(msg.value())
+                    if keys:
+                        out.append({'key':msg.key(), 'value':msg.value()})
+                    else:
+                        out.append(msg.value())
                 if high <= msg.offset():
                     break
             else:

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -6,6 +6,7 @@ import random
 import requests
 import shlex
 import subprocess
+import time
 from tornado import gen
 
 from ..core import Stream
@@ -103,6 +104,14 @@ def kafka_service():
     yield _kafka[0], TOPIC
 
 
+def split(messages):
+    parsed = []
+    for message in messages:
+        message = message.decode("utf-8")
+        parsed.append(int(message.split('-')[1]))
+    return parsed
+
+
 @gen_test(timeout=60)
 def test_from_kafka():
     j = random.randint(0, 10000)
@@ -189,14 +198,15 @@ def test_kafka_batch():
             'group.id': 'streamz-test%i' % j}
     with kafka_service() as kafka:
         kafka, TOPIC = kafka
-        stream = Stream.from_kafka_batched(TOPIC, ARGS)
+        stream = Stream.from_kafka_batched(TOPIC, ARGS, keys=True)
         out = stream.sink_to_list()
         stream.start()
         for i in range(10):
-            kafka.produce(TOPIC, b'value-%d' % i)
+            kafka.produce(TOPIC, b'value-%d' % i, b'%d' % i)
         kafka.flush()
         # out may still be empty or first item of out may be []
-        wait_for(lambda: any(out) and out[-1][-1] == b'value-9', 10, period=0.2)
+        wait_for(lambda: any(out) and out[-1][-1]['value'] == b'value-9', 10, period=0.2)
+        assert out[-1][-1]['key'] == b'9'
         stream.upstream.stopped = True
 
 
@@ -207,8 +217,8 @@ def test_kafka_dask_batch(c, s, w1, w2):
             'group.id': 'streamz-test%i' % j}
     with kafka_service() as kafka:
         kafka, TOPIC = kafka
-        stream = Stream.from_kafka_batched(TOPIC, ARGS, asynchronous=True,
-                                           dask=True)
+        stream = Stream.from_kafka_batched(TOPIC, ARGS, keys=True,
+                                           asynchronous=True, dask=True)
         out = stream.gather().sink_to_list()
         stream.start()
         yield gen.sleep(5)  # this frees the loop while dask workers report in
@@ -217,5 +227,219 @@ def test_kafka_dask_batch(c, s, w1, w2):
             kafka.produce(TOPIC, b'value-%d' % i)
         kafka.flush()
         yield await_for(lambda: any(out), 10, period=0.2)
-        assert b'value-1' in out[0]
+        assert {'key':None, 'value':b'value-1'} in out[0]
         stream.upstream.stopped = True
+
+
+def test_kafka_batch_checkpointing_sync_nodes():
+    '''
+    Streams 1 and 3 have different consumer groups, while Stream 2
+    has the same group as 1. Hence, Stream 2 does not re-read the
+    data that had been finished processing by Stream 1, i.e. it
+    picks up from where Stream 1 had left off.
+    '''
+    j1 = random.randint(0, 10000)
+    ARGS1 = {'bootstrap.servers': 'localhost:9092',
+            'group.id': 'streamz-test%i' % j1,
+            'enable.auto.commit': False}
+    j2 = j1 + 1
+    ARGS2 = {'bootstrap.servers': 'localhost:9092',
+            'group.id': 'streamz-test%i' % j2,
+            'enable.auto.commit': False}
+    with kafka_service() as kafka:
+        kafka, TOPIC = kafka
+        for i in range(10):
+            kafka.produce(TOPIC, b'value-%d' % i)
+        kafka.flush()
+        stream1 = Stream.from_kafka_batched(TOPIC, ARGS1)
+        out1 = stream1.map(split).filter(lambda x: x[-1] % 2 == 1).sink_to_list()
+        stream1.start()
+        wait_for(lambda: any(out1) and out1[-1][-1] == b'value-9', 10, period=0.2)
+        stream1.upstream.stopped = True
+        stream2 = Stream.from_kafka_batched(TOPIC, ARGS1)
+        out2 = stream2.map(split).filter(lambda x: x[-1] % 2 == 1).sink_to_list()
+        stream2.start()
+        time.sleep(5)
+        assert len(out2) == 0
+        stream2.upstream.stopped = True
+        stream3 = Stream.from_kafka_batched(TOPIC, ARGS2)
+        out3 = stream3.map(split).filter(lambda x: x[-1] % 2 == 1).sink_to_list()
+        stream3.start()
+        wait_for(lambda: any(out3) and out3[-1][-1] == b'value-9', 10, period=0.2)
+        stream3.upstream.stopped = True
+
+
+@gen_cluster(client=True, timeout=60)
+def test_kafka_dask_checkpointing_sync_nodes(c, s, w1, w2):
+    '''
+    Testing whether Dask's scatter and gather works in conformity with
+    the reference counting checkpointing implementation.
+    '''
+    j1 = random.randint(0, 10000)
+    ARGS1 = {'bootstrap.servers': 'localhost:9092',
+            'group.id': 'streamz-test%i' % j1,
+            'enable.auto.commit': False}
+    j2 = j1 + 1
+    ARGS2 = {'bootstrap.servers': 'localhost:9092',
+            'group.id': 'streamz-test%i' % j2,
+            'enable.auto.commit': False}
+    with kafka_service() as kafka:
+        kafka, TOPIC = kafka
+        for i in range(10):
+            kafka.produce(TOPIC, b'value-%d' % i)
+        kafka.flush()
+        stream1 = Stream.from_kafka_batched(TOPIC, ARGS1, asynchronous=True,
+                                           dask=True)
+        out1 = stream1.map(split).gather().filter(lambda x: x[-1] % 2 == 1).sink_to_list()
+        stream1.start()
+        yield await_for(lambda: any(out1) and out1[-1][-1] == b'value-9', 10, period=0.2)
+        stream1.upstream.stopped = True
+        stream2 = Stream.from_kafka_batched(TOPIC, ARGS1, asynchronous=True,
+                                           dask=True)
+        out2 = stream2.map(split).gather().filter(lambda x: x[-1] % 2 == 1).sink_to_list()
+        stream2.start()
+        time.sleep(5)
+        assert len(out2) == 0
+        stream2.upstream.stopped = True
+        stream3 = Stream.from_kafka_batched(TOPIC, ARGS2, asynchronous=True,
+                                           dask=True)
+        out3 = stream3.map(split).gather().filter(lambda x: x[-1] % 2 == 1).sink_to_list()
+        stream3.start()
+        yield await_for(lambda: any(out3) and out3[-1][-1] == b'value-9', 10, period=0.2)
+        stream3.upstream.stopped = True
+
+
+def test_kafka_batch_checkpointing_async_nodes_1():
+    '''
+    In async nodes like partition & sliding window, data is checkpointed only after
+    the pipeline has finished processing it.
+    '''
+    j = random.randint(0, 10000)
+    ARGS = {'bootstrap.servers': 'localhost:9092',
+            'group.id': 'streamz-test%i' % j,
+            'enable.auto.commit': False}
+    with kafka_service() as kafka:
+        kafka, TOPIC = kafka
+        stream1 = Stream.from_kafka_batched(TOPIC, ARGS)
+        out1 = stream1.partition(2).sliding_window(2, return_partial=False).sink_to_list()
+        stream1.start()
+        for i in range(0,2):
+            kafka.produce(TOPIC, b'value-%d' % i)
+            kafka.flush()
+            time.sleep(2)
+        assert len(out1) == 0
+        #Stream stops before data can finish processing, hence no checkpointing.
+        stream1.upstream.stopped = True
+        stream1.destroy()
+        stream2 = Stream.from_kafka_batched(TOPIC, ARGS)
+        out2 = stream2.partition(2).sliding_window(2, return_partial=False).sink_to_list()
+        stream2.start()
+        time.sleep(2)
+        for i in range(2,6):
+            kafka.produce(TOPIC, b'value-%d' % i)
+            kafka.flush()
+            time.sleep(2)
+        assert len(out2) == 1
+        assert out2 == [(([b'value-0', b'value-1'], [b'value-2']), ([b'value-3'], [b'value-4']))]
+        #Some data gets processed and exits pipeline before the stream stops, hence checkpointing complete.
+        stream2.upstream.stopped = True
+        stream2.destroy()
+        stream3 = Stream.from_kafka_batched(TOPIC, ARGS)
+        out3 = stream3.sink_to_list()
+        stream3.start()
+        time.sleep(2)
+        #Stream picks up from where it left before, i.e., from the last committed offset.
+        assert len(out3) == 1 and out3[0] == [b'value-3', b'value-4', b'value-5']
+        stream3.upstream.stopped = True
+
+
+def test_kafka_batch_checkpointing_async_nodes_2():
+    '''
+    In async nodes like zip_latest, zip, combine_latest which involve multiple streams,
+    checkpointing in each stream commits offsets after the datum in that specific stream
+    is processed completely and exits the pipeline.
+    '''
+    CONSUMER_ARGS1 = {'bootstrap.servers': 'localhost:9092',
+                      'group.id': 'zip_latest',
+                      'enable.auto.commit': False}
+    CONSUMER_ARGS2 = {'bootstrap.servers': 'localhost:9092',
+                      'group.id': 'zip',
+                      'enable.auto.commit': False}
+    CONSUMER_ARGS3 = {'bootstrap.servers': 'localhost:9092',
+                      'group.id': 'combine_latest',
+                      'enable.auto.commit': False}
+    TOPIC1 = 'test1'
+    TOPIC2 = 'test2'
+    with kafka_service() as kafka:
+        kafka, TOPIC = kafka
+        stream1 = Stream.from_kafka_batched(TOPIC1, CONSUMER_ARGS1)
+        stream1.start()
+        stream2 = Stream.from_kafka_batched(TOPIC2, CONSUMER_ARGS1)
+        stream2.start()
+        out1 = stream1.zip_latest(stream2).sink_to_list()
+        stream3 = Stream.from_kafka_batched(TOPIC1, CONSUMER_ARGS2)
+        stream3.start()
+        stream4 = Stream.from_kafka_batched(TOPIC2, CONSUMER_ARGS2)
+        stream4.start()
+        out2 = stream3.zip(stream4).sink_to_list()
+        stream5 = Stream.from_kafka_batched(TOPIC1, CONSUMER_ARGS3)
+        stream5.start()
+        stream6 = Stream.from_kafka_batched(TOPIC2, CONSUMER_ARGS3)
+        stream6.start()
+        out3 = stream5.combine_latest(stream6).sink_to_list()
+        kafka.produce(TOPIC1, b'value-0')
+        time.sleep(2)
+        kafka.produce(TOPIC2, b'value-1')
+        '''
+        1. zip_latest emits a tuple, the lossless stream 1 commits an offset.
+        2. Since zip emits a tuple, streams 3 and 4 commit offsets in their topics.
+        3. combine_latest does not commit any offset since data is still to be used.
+        '''
+        time.sleep(2)
+        kafka.produce(TOPIC2, b'value-2')
+        '''
+        1. zip_latest emits a tuple, the lossless stream 1 commits an offset.
+        2. zip does not commit any offset.
+        3. combine_latest commits an offset in stream 5.
+        '''
+        time.sleep(2)
+        kafka.produce(TOPIC2, b'value-3')
+        '''
+        1. zip_latest emits a tuple, the non-lossless stream 2 commits an offset.
+        2. Since zip emits a tuple, streams 3 and 4 commit offsets in their topics.
+        3. combine_latest commits an offset in stream 6.
+        '''
+        time.sleep(2)
+        stream1.destroy()
+        stream2.destroy()
+        stream3.destroy()
+        stream4.destroy()
+        stream5.destroy()
+        stream6.destroy()
+        stream1 = Stream.from_kafka_batched(TOPIC1, CONSUMER_ARGS1)
+        out1 = stream1.sink_to_list()
+        stream1.start()
+        stream2 = Stream.from_kafka_batched(TOPIC2, CONSUMER_ARGS1)
+        out2 = stream2.sink_to_list()
+        stream2.start()
+        stream3 = Stream.from_kafka_batched(TOPIC1, CONSUMER_ARGS2)
+        out3 = stream3.sink_to_list()
+        stream3.start()
+        stream4 = Stream.from_kafka_batched(TOPIC2, CONSUMER_ARGS2)
+        out4 = stream4.sink_to_list()
+        stream4.start()
+        stream5 = Stream.from_kafka_batched(TOPIC1, CONSUMER_ARGS3)
+        out5 = stream5.sink_to_list()
+        stream5.start()
+        stream6 = Stream.from_kafka_batched(TOPIC2, CONSUMER_ARGS3)
+        out6 = stream6.sink_to_list()
+        stream6.start()
+        '''
+        Each stream/group.id picks up from their last committed offset.
+        '''
+        assert out1 == []
+        assert out2 == [[b'value-3']]
+        assert out3 == []
+        assert out4 == []
+        assert out5 == [[b'value-2']]
+        assert out6 == [[b'value-3']]


### PR DESCRIPTION
This change is to use reference counters to check when data is done. Then, those counters are used by sources to know when to commit offsets. There are two primary types of nodes for the purposes here: synchronous nodes and asynchronous nodes. Synchronous do not exit from the `update` method before calling `_emit`. The reference counting happens in the `Stream` base class in the `_emit` function.  Asynchronous nodes, however do return and will call `_emit` at some time in the future. These nodes are more complicated because the metadata must be managed.

## Synchronous nodes
The only thing changed here is that the metadata is passed forward to the next node.
### Core
* accumulate
* filter
* map
* pluck
* sink
* rate_limit
* slice
* starmap
* union
* unique
* flatten - The only special case for sync' nodes. The reference to the reference counters can not be duplicated for each messages or their counts will be decremented below zero. The metadata is emitted with the last element.

### Dask
* accumulate
* map
* starmap

## Async' nodes (grouped by strategy)
### Core
#### Input to output is 1:1
Couple the metadata with the data on the cache and pull the metadata off the cache with the data and emit them together.
  * buffer
  * delay
  * latest

#### Input single values and output collections
The metadata is cached with the data and emitted a collection.
  * collect
  * partition
  * sliding_window
  * timed_window

#### Multiple stream inputs combined into a single output 
All datum that is emitted downstream will have it's accompanying metadata emitted with it as a collection.
  * combine_latest
  * zip
  * zip_latest
  
### Dask
#### A yield is performed before _emit
The metadata is a simple pass-through just as in sync nodes, but the reference counter will need to incremented here as there is a yield before the `_emit` call
  * gather
  * scatter
