### PR TITLE
Fix collections.abc deprecation warnings

### DIFF
--- a/streamz/core.py
+++ b/streamz/core.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     PollIOLoop = None  # dropped in tornado 6.0
 
-from collections import Iterable
+from collections.abc import Iterable
 
 from .compatibility import get_thread_identity
 from .orderedweakset import OrderedWeakrefSet

--- a/streamz/orderedweakset.py
+++ b/streamz/orderedweakset.py
@@ -7,7 +7,7 @@ import collections
 import weakref
 
 
-class OrderedSet(collections.MutableSet):
+class OrderedSet(collections.abc.MutableSet):
     def __init__(self, values=()):
         self._od = collections.OrderedDict().fromkeys(values)
 


### PR DESCRIPTION
It appears that the abstract collection types in the `collections` module are being moved to `collections.abc` in Python 3.9. This change anticipates the deprecation and fixes the resulting warnings (see below).

 > /envs/test-env/lib/python3.7/site-packages/streamz/core.py:23  /envs/test-env/lib/python3.7/site-packages/streamz/core.py:23: **DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working**
        `from collections import Iterable`
>
> /envs/test-env/lib/python3.7/site-packages/streamz/orderedweakset.py:10  /envs/test-env/lib/python3.7/site-packages/streamz/orderedweakset.py:10: **DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working**
           `class OrderedSet(collections.MutableSet):`
>
> -- Docs: https://docs.pytest.org/en/latest/warnings.html