### PR TITLE
Adding Kafka message keys PR overwritten by Checkpointing + max_batch_size parameter for from_kafka_batched

### DIFF
--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -469,7 +469,7 @@ class FromKafkaBatched(Stream):
         import confluent_kafka as ck
 
         def commit(_part):
-            topic, part_no, _, offset = _part[1:]
+            topic, part_no, _, _, offset = _part[1:]
             _tp = ck.TopicPartition(topic, part_no, offset + 1)
             self.consumer.commit(offsets=[_tp], asynchronous=True)
 

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -198,7 +198,7 @@ def test_kafka_batch():
             'group.id': 'streamz-test%i' % j}
     with kafka_service() as kafka:
         kafka, TOPIC = kafka
-        stream = Stream.from_kafka_batched(TOPIC, ARGS, keys=True)
+        stream = Stream.from_kafka_batched(TOPIC, ARGS, max_batch_size=4, keys=True)
         out = stream.sink_to_list()
         stream.start()
         for i in range(10):
@@ -207,6 +207,8 @@ def test_kafka_batch():
         # out may still be empty or first item of out may be []
         wait_for(lambda: any(out) and out[-1][-1]['value'] == b'value-9', 10, period=0.2)
         assert out[-1][-1]['key'] == b'9'
+        # max_batch_size checks
+        assert len(out[0]) == len(out[1]) == 4 and len(out) == 3
         stream.upstream.stopped = True
 
 

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -202,7 +202,7 @@ def test_kafka_batch():
         out = stream.sink_to_list()
         stream.start()
         for i in range(10):
-            kafka.produce(TOPIC, b'value-%d' % i)
+            kafka.produce(TOPIC, b'value-%d' % i, b'%d' % i)
         kafka.flush()
         # out may still be empty or first item of out may be []
         wait_for(lambda: any(out) and out[-1][-1]['value'] == b'value-9', 10, period=0.2)
@@ -224,7 +224,7 @@ def test_kafka_dask_batch(c, s, w1, w2):
         yield gen.sleep(5)  # this frees the loop while dask workers report in
         assert isinstance(stream, DaskStream)
         for i in range(10):
-            kafka.produce(TOPIC, b'value-%d' % i, b'%d' % i)
+            kafka.produce(TOPIC, b'value-%d' % i)
         kafka.flush()
         yield await_for(lambda: any(out), 10, period=0.2)
         assert {'key':None, 'value':b'value-1'} in out[0]

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -198,14 +198,15 @@ def test_kafka_batch():
             'group.id': 'streamz-test%i' % j}
     with kafka_service() as kafka:
         kafka, TOPIC = kafka
-        stream = Stream.from_kafka_batched(TOPIC, ARGS)
+        stream = Stream.from_kafka_batched(TOPIC, ARGS, keys=True)
         out = stream.sink_to_list()
         stream.start()
         for i in range(10):
             kafka.produce(TOPIC, b'value-%d' % i)
         kafka.flush()
         # out may still be empty or first item of out may be []
-        wait_for(lambda: any(out) and out[-1][-1] == b'value-9', 10, period=0.2)
+        wait_for(lambda: any(out) and out[-1][-1]['value'] == b'value-9', 10, period=0.2)
+        assert out[-1][-1]['key'] == b'9'
         stream.upstream.stopped = True
 
 
@@ -216,17 +217,17 @@ def test_kafka_dask_batch(c, s, w1, w2):
             'group.id': 'streamz-test%i' % j}
     with kafka_service() as kafka:
         kafka, TOPIC = kafka
-        stream = Stream.from_kafka_batched(TOPIC, ARGS, asynchronous=True,
-                                           dask=True)
+        stream = Stream.from_kafka_batched(TOPIC, ARGS, keys=True,
+                                           asynchronous=True, dask=True)
         out = stream.gather().sink_to_list()
         stream.start()
         yield gen.sleep(5)  # this frees the loop while dask workers report in
         assert isinstance(stream, DaskStream)
         for i in range(10):
-            kafka.produce(TOPIC, b'value-%d' % i)
+            kafka.produce(TOPIC, b'value-%d' % i, b'%d' % i)
         kafka.flush()
         yield await_for(lambda: any(out), 10, period=0.2)
-        assert b'value-1' in out[0]
+        assert {'key':None, 'value':b'value-1'} in out[0]
         stream.upstream.stopped = True
 
 


### PR DESCRIPTION
Adding #304 back after being overwritten by #306.

This PR also adds `max_batch_size` as a parameter to `from_kafka_batched` — maximum number of messages per partition to be read per batch from Kafka. Currently, if there's a million messages in topic partition, streamz attempts to read all of them in one go, which can be a problem and overload/overflow memory. 