### PR TITLE
Add parameter to allow reading from latest offsets in Kafka.

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -95,6 +95,7 @@ Definitions
 
 .. autofunction:: filenames
 .. autofunction:: from_kafka
+.. autofunction:: from_kafka_batched
 .. autofunction:: from_textfile
 
 .. currentmodule:: streamz.dask

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -457,7 +457,7 @@ class FromKafkaBatched(Stream):
                  keys=False, **kwargs):
         self.consumer_params = consumer_params
         # Override the auto-commit config to enforce custom streamz checkpointing
-        self.consumer_params["enable.auto.commit"] = False
+        self.consumer_params['enable.auto.commit'] = False
         self.topic = topic
         self.npartitions = npartitions
         self.positions = [0] * npartitions
@@ -507,8 +507,11 @@ class FromKafkaBatched(Stream):
                             tp, timeout=0.1)
                     except (RuntimeError, ck.KafkaException):
                         continue
-                    if self.latest is True or self.consumer_params["auto.offset.reset"] == "latest":
+                    if self.latest is True:
                         self.positions[partition] = high
+                    if 'auto.offset.reset' in self.consumer_params.keys():
+                        if self.consumer_params['auto.offset.reset'] == "latest":
+                            self.positions[partition] = high
                     current_position = self.positions[partition]
                     lowest = max(current_position, low)
                     if high > lowest + self.max_batch_size:

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -504,6 +504,12 @@ class FromKafkaBatched(Stream):
                         low, high = self.consumer.get_watermark_offsets(
                             tp, timeout=0.1)
                     except (RuntimeError, ck.KafkaException):
+                        print("Recreating consumer")
+                        self.consumer.unsubscribe()
+                        self.consumer.close()
+                        self.consumer = ck.Consumer(self.consumer_params)
+                        self.consumer.subscribe([self.topic])
+                        time.sleep(5)
                         continue
                     if self.latest is True:
                         self.positions[partition] = high

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -504,10 +504,6 @@ class FromKafkaBatched(Stream):
                         low, high = self.consumer.get_watermark_offsets(
                             tp, timeout=0.1)
                     except (RuntimeError, ck.KafkaException):
-                        self.consumer.unsubscribe()
-                        self.consumer.close()
-                        self.consumer = ck.Consumer(self.consumer_params)
-                        self.consumer.subscribe([self.topic])
                         continue
                     if self.latest is True:
                         self.positions[partition] = high

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -457,7 +457,7 @@ class FromKafkaBatched(Stream):
                  keys=False, **kwargs):
         self.consumer_params = consumer_params
         # Override the auto-commit config to enforce custom streamz checkpointing
-        self.consumer_params["enable.auto.commit"] = "false"
+        self.consumer_params["enable.auto.commit"] = False
         self.topic = topic
         self.npartitions = npartitions
         self.positions = [0] * npartitions

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -504,12 +504,10 @@ class FromKafkaBatched(Stream):
                         low, high = self.consumer.get_watermark_offsets(
                             tp, timeout=0.1)
                     except (RuntimeError, ck.KafkaException):
-                        print("Recreating consumer")
                         self.consumer.unsubscribe()
                         self.consumer.close()
                         self.consumer = ck.Consumer(self.consumer_params)
                         self.consumer.subscribe([self.topic])
-                        time.sleep(5)
                         continue
                     if self.latest is True:
                         self.positions[partition] = high

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -521,7 +521,7 @@ class FromKafkaBatched(Stream):
                                     self.keys, lowest, high - 1))
                         self.positions[partition] = high
                 self.latest = False
-                self.consumer_params["auto.offset.reset"] = "earliest"
+                self.consumer_params['auto.offset.reset'] = "earliest"
 
                 for part in out:
                     yield self.loop.add_callback(checkpoint_emit, part)

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -206,6 +206,7 @@ def test_kafka_batch():
                                            latest=True, keys=True)
         out = stream.sink_to_list()
         stream.start()
+        time.sleep(5)
         for i in range(10):
             kafka.produce(TOPIC, b'value-%d' % i, b'%d' % i)
         kafka.flush()

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -195,15 +195,15 @@ def test_from_kafka_thread():
 def test_kafka_batch():
     j = random.randint(0, 10000)
     ARGS = {'bootstrap.servers': 'localhost:9092',
-            'group.id': 'streamz-test%i' % j}
+            'group.id': 'streamz-test%i' % j,
+            'auto.offset.reset': 'latest'}
     with kafka_service() as kafka:
         kafka, TOPIC = kafka
         # These messages aren't read since Stream starts reading from latest offsets
         for i in range(10):
             kafka.produce(TOPIC, b'value-%d' % i, b'%d' % i)
         kafka.flush()
-        stream = Stream.from_kafka_batched(TOPIC, ARGS, max_batch_size=4,
-                                           latest=True, keys=True)
+        stream = Stream.from_kafka_batched(TOPIC, ARGS, max_batch_size=4, keys=True)
         out = stream.sink_to_list()
         stream.start()
         time.sleep(5)

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -198,7 +198,12 @@ def test_kafka_batch():
             'group.id': 'streamz-test%i' % j}
     with kafka_service() as kafka:
         kafka, TOPIC = kafka
-        stream = Stream.from_kafka_batched(TOPIC, ARGS, max_batch_size=4, keys=True)
+        # These messages aren't read since Stream starts reading from latest offsets
+        for i in range(10):
+            kafka.produce(TOPIC, b'value-%d' % i, b'%d' % i)
+        kafka.flush()
+        stream = Stream.from_kafka_batched(TOPIC, ARGS, max_batch_size=4,
+                                           latest=True, keys=True)
         out = stream.sink_to_list()
         stream.start()
         for i in range(10):


### PR DESCRIPTION
Currently, a stream starts reading from the earliest message available in the topic. Sometimes, if a topic has a million messages, or if a stream restarts, you might not want to read from the earliest record. This would allow the stream to start reading from the 'latest' offset in each partition.

Would love to have ideas here, if there's a more efficient implementation possible for this.