### PR TITLE
Union of Kafka streams should not freeze when either of the sources freezes/fails.

### DIFF
--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -504,6 +504,12 @@ class FromKafkaBatched(Stream):
                         low, high = self.consumer.get_watermark_offsets(
                             tp, timeout=0.1)
                     except (RuntimeError, ck.KafkaException):
+                        print("Recreating consumer")
+                        self.consumer.unsubscribe()
+                        self.consumer.close()
+                        self.consumer = ck.Consumer(self.consumer_params)
+                        self.consumer.subscribe([self.topic])
+                        time.sleep(5)
                         continue
                     if self.latest is True:
                         self.positions[partition] = high

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -504,10 +504,6 @@ class FromKafkaBatched(Stream):
                         low, high = self.consumer.get_watermark_offsets(
                             tp, timeout=0.1)
                     except (RuntimeError, ck.KafkaException):
-                        self.consumer.unsubscribe()
-                        self.consumer.close()
-                        self.consumer = ck.Consumer(self.consumer_params)
-                        self.consumer.subscribe([self.topic])
                         continue
                     if self.latest is True:
                         self.positions[partition] = high

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -504,6 +504,10 @@ class FromKafkaBatched(Stream):
                         low, high = self.consumer.get_watermark_offsets(
                             tp, timeout=0.1)
                     except (RuntimeError, ck.KafkaException):
+                        self.consumer.unsubscribe()
+                        self.consumer.close()
+                        self.consumer = ck.Consumer(self.consumer_params)
+                        self.consumer.subscribe([self.topic])
                         continue
                     if self.latest is True:
                         self.positions[partition] = high

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -504,12 +504,10 @@ class FromKafkaBatched(Stream):
                         low, high = self.consumer.get_watermark_offsets(
                             tp, timeout=0.1)
                     except (RuntimeError, ck.KafkaException):
-                        print("Recreating consumer")
                         self.consumer.unsubscribe()
                         self.consumer.close()
                         self.consumer = ck.Consumer(self.consumer_params)
                         self.consumer.subscribe([self.topic])
-                        time.sleep(5)
                         continue
                     if self.latest is True:
                         self.positions[partition] = high

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -453,15 +453,13 @@ class from_kafka(Source):
 class FromKafkaBatched(Stream):
     """Base class for both local and cluster-based batched kafka processing"""
     def __init__(self, topic, consumer_params, poll_interval='1s',
-                 npartitions=1, max_batch_size=10000, latest=False,
-                 keys=False, **kwargs):
+                 npartitions=1, max_batch_size=10000, keys=False, **kwargs):
         self.consumer_params = consumer_params
         self.topic = topic
         self.npartitions = npartitions
         self.positions = [0] * npartitions
         self.poll_interval = convert_interval(poll_interval)
         self.max_batch_size = max_batch_size
-        self.latest = latest
         self.keys = keys
         self.stopped = True
 
@@ -509,8 +507,6 @@ class FromKafkaBatched(Stream):
                         self.consumer = ck.Consumer(self.consumer_params)
                         self.consumer.subscribe([self.topic])
                         continue
-                    if self.latest is True:
-                        self.positions[partition] = high
                     current_position = self.positions[partition]
                     lowest = max(current_position, low)
                     if high > lowest + self.max_batch_size:
@@ -519,7 +515,6 @@ class FromKafkaBatched(Stream):
                         out.append((self.consumer_params, self.topic, partition,
                                     self.keys, lowest, high - 1))
                         self.positions[partition] = high
-                self.latest = False
 
                 for part in out:
                     yield self.loop.add_callback(checkpoint_emit, part)
@@ -545,8 +540,7 @@ class FromKafkaBatched(Stream):
 @Stream.register_api(staticmethod)
 def from_kafka_batched(topic, consumer_params, poll_interval='1s',
                        npartitions=1, start=False, dask=False,
-                       max_batch_size=10000, keys=False,
-                       latest=False, **kwargs):
+                       max_batch_size=10000, keys=False, **kwargs):
     """ Get messages and keys (optional) from Kafka in batches
 
     Uses the confluent-kafka library,
@@ -583,8 +577,6 @@ def from_kafka_batched(topic, consumer_params, poll_interval='1s',
         Whether to start polling upon instantiation
     max_batch_size: int
         The maximum number of messages per partition to be consumed per batch
-    latest: bool (False)
-        Whether to start reading messages from the start of the topic or from the latest offset
     keys: bool (False)
         Whether to extract keys along with the messages. If True, this will yield each message as a dict:
         {'key':msg.key(), 'value':msg.value()}
@@ -604,7 +596,6 @@ def from_kafka_batched(topic, consumer_params, poll_interval='1s',
                               poll_interval=poll_interval,
                               npartitions=npartitions,
                               max_batch_size=max_batch_size,
-                              latest=latest,
                               keys=keys,
                               **kwargs)
     if dask:

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -206,6 +206,7 @@ def test_kafka_batch():
                                            latest=True, keys=True)
         out = stream.sink_to_list()
         stream.start()
+        time.sleep(5)
         for i in range(10):
             kafka.produce(TOPIC, b'value-%d' % i, b'%d' % i)
         kafka.flush()

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -198,15 +198,9 @@ def test_kafka_batch():
             'group.id': 'streamz-test%i' % j}
     with kafka_service() as kafka:
         kafka, TOPIC = kafka
-        # These messages aren't read since Stream starts reading from latest offsets
-        for i in range(10):
-            kafka.produce(TOPIC, b'value-%d' % i, b'%d' % i)
-        kafka.flush()
-        stream = Stream.from_kafka_batched(TOPIC, ARGS, max_batch_size=4,
-                                           latest=True, keys=True)
+        stream = Stream.from_kafka_batched(TOPIC, ARGS, max_batch_size=4, keys=True)
         out = stream.sink_to_list()
         stream.start()
-        time.sleep(5)
         for i in range(10):
             kafka.produce(TOPIC, b'value-%d' % i, b'%d' % i)
         kafka.flush()

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -198,7 +198,12 @@ def test_kafka_batch():
             'group.id': 'streamz-test%i' % j}
     with kafka_service() as kafka:
         kafka, TOPIC = kafka
-        stream = Stream.from_kafka_batched(TOPIC, ARGS, max_batch_size=4, keys=True)
+        # These messages aren't read since Stream starts reading from latest offsets
+        for i in range(10):
+            kafka.produce(TOPIC, b'value-%d' % i, b'%d' % i)
+        kafka.flush()
+        stream = Stream.from_kafka_batched(TOPIC, ARGS, max_batch_size=4,
+                                           latest=True, keys=True)
         out = stream.sink_to_list()
         stream.start()
         for i in range(10):


### PR DESCRIPTION
PR tries to resolve #308. 

In the event when CK encounters an exception at `get_watermark_offsets`, we typically need to recreate (resubscribe to the topic) the consumer in case we want to consume the next time around when Kafka is up again. I'm thinking there might be a cleaner way than this, though.

Below is the example notebook I ran to confirm if this works. I have also attached the output of each cell. 

```
from streamz import Stream
import random
import confluent_kafka as ck

PRODUCER_ARGS = {
    "bootstrap.servers": "localhost:9092"
}
producer = ck.Producer(PRODUCER_ARGS)
j1 = random.randint(0, 10000)
CONSUMER_ARGS1 = {
    "bootstrap.servers": "localhost:9092",
    "group.id": 'streamz-test%i' % j1,
    "enable.auto.commit": "false",
    "enable.partition.eof": "true",
    "session.timeout.ms": "60000",
    "auto.offset.reset": "earliest"
}
TOPIC1 = "prod"
TOPIC2 = "backup"

a = Stream.from_kafka_batched(TOPIC1, CONSUMER_ARGS1)
a.start()

b = Stream.from_kafka_batched(TOPIC2, CONSUMER_ARGS1)
b.start()

a.union(b).sink(print)
```
```
producer.produce(TOPIC1, '{"name":"Prod", "amount":50}', "")
producer.produce(TOPIC2, '{"name":"Backup", "amount":100}', "")
```
[b'{"name":"Backup", "amount":100}']
[b'{"name":"Prod", "amount":50}']

### After Deleting prod topic ###

```
producer.produce(TOPIC2, '{"name":"Backup", "amount":150}', "")
producer.produce(TOPIC2, '{"name":"Backup", "amount":200}', "")
```
[b'{"name":"Backup", "amount":150}', b'{"name":"Backup", "amount":200}']

### After Recreating prod topic ###

```
producer.produce(TOPIC1, '{"name":"Prod", "amount":50}', "")
producer.produce(TOPIC1, '{"name":"Prod", "amount":250}', "")
producer.produce(TOPIC1, '{"name":"Prod", "amount":300}', "")
producer.produce(TOPIC2, '{"name":"Backup", "amount":350}', "")
```

[b'{"name":"Prod", "amount":250}', b'{"name":"Prod", "amount":300}']
[b'{"name":"Backup", "amount":350}']

Should we add a test for this?
