### PR TITLE
Wrap the items passed to `client.scatter` with a dict

### DIFF
--- a/streamz/dask.py
+++ b/streamz/dask.py
@@ -109,7 +109,7 @@ class scatter(DaskStream):
         # lists and dicts. So we always use a dict here to be sure
         # we know the format exactly. The key will be taken as the
         # dask identifier of the data.
-        tokenized_x = type(x).__name__ + "-" + tokenize(x)
+        tokenized_x = f"{type(x).__name__}-{tokenize(x)}"
         future_as_dict = yield client.scatter({tokenized_x: x}, asynchronous=True)
         future = future_as_dict[tokenized_x]
         f = yield self._emit(future, metadata=metadata)

--- a/streamz/dask.py
+++ b/streamz/dask.py
@@ -5,6 +5,7 @@ from operator import getitem
 from tornado import gen
 
 from dask.compatibility import apply
+from dask.base import tokenize
 from distributed.client import default_client
 
 from .core import Stream
@@ -103,7 +104,14 @@ class scatter(DaskStream):
         client = default_client()
 
         self._retain_refs(metadata)
-        future = yield client.scatter(x, asynchronous=True)
+        # We need to make sure that x is treated as it is by dask
+        # However, client.scatter works internally different for
+        # lists and dicts. So we always use a dict here to be sure
+        # we know the format exactly. The key will be taken as the
+        # dask identifier of the data.
+        tokenized_x = type(x).__name__ + "-" + tokenize(x)
+        future_as_dict = yield client.scatter({tokenized_x: x}, asynchronous=True)
+        future = future_as_dict[tokenized_x]
         f = yield self._emit(future, metadata=metadata)
         self._release_refs(metadata)
 

--- a/streamz/tests/test_dask.py
+++ b/streamz/tests/test_dask.py
@@ -32,7 +32,7 @@ def test_map(c, s, a, b):
 def test_map_on_dict(c, s, a, b):
     # dask treats dicts differently, so we have to make sure
     # the user sees no difference in the streamz api.
-    # Regression test agains #336
+    # Regression test against #336
     def add_to_dict(d):
         d["x"] = d["i"]
         return d


### PR DESCRIPTION
As discussed in #336 dasks `client.scatter` treats dicts and lists different from any other object. This is good for raw dask usages, but not wanted in streamz. Therefore I always wrap with a dict now, so that we get consistent behavior.
The key of the dict will be used to identify the data on the cluster. I am following the same convention as dask itself by choosing the key.