### PR TITLE
Added PeriodicDataFrame

### DIFF
--- a/docs/source/collections-api.rst
+++ b/docs/source/collections-api.rst
@@ -87,6 +87,9 @@ Dataframes
    Rolling.var
 
 .. autosummary::
+   PeriodicDataFrame
+
+.. autosummary::
    Random
 
 Details

--- a/docs/source/dataframes.rst
+++ b/docs/source/dataframes.rst
@@ -190,7 +190,8 @@ events, and topologies, but what if you simply want to run some Python
 function periodically and collect or plot the results?
 
 streamz provides a high-level convenience class for this purpose, called
-a PeriodicDataFrame. A PeriodicDataFrame uses Tornado's event loop to
+a PeriodicDataFrame. A PeriodicDataFrame uses Python's asyncio event loop
+(used as part of Tornado in Jupyter and other interactive frameworks) to
 call a user-provided function at a regular interval, collecting the results
 and making them available for later processing.
 

--- a/docs/source/dataframes.rst
+++ b/docs/source/dataframes.rst
@@ -221,7 +221,7 @@ results of system calls or other isolated actions, but any number of
 entries can be returned by the dataframe in a single batch. To
 facilitate collecting such batches, the callback is invoked with
 ``last`` (the time of the previous invocation) and ``now`` (the
-time of the current invocation. The callback can then generate or
+time of the current invocation). The callback can then generate or
 query for just the values in that time range.
 
 Arbitrary keyword arguments can be provided to the PeriodicDataFrame
@@ -252,4 +252,3 @@ Once you have a PeriodicDataFrame defined using such callbacks, you
 can then use all the rest of the functionality supported by streamz,
 including aggregations, rolling windows, etc., and streaming
 `visualization. <plotting>`_
-

--- a/docs/source/dataframes.rst
+++ b/docs/source/dataframes.rst
@@ -226,7 +226,7 @@ objects. The callback can then generate or query for just the values
 in that time range.
 
 Arbitrary keyword arguments can be provided to the PeriodicDataFrame
-constructor, which will be passed into the callback that its behavior
+constructor, which will be passed into the callback so that its behavior
 can be parameterized.
 
 For instance, you can write a callback to return a suitable number of

--- a/streamz/dataframe/__init__.py
+++ b/streamz/dataframe/__init__.py
@@ -1,3 +1,3 @@
 from .core import (DataFrame, DataFrames, Frame, Frames, Series, Seriess, Index,
-                   Rolling, Window, Random, GroupBy)
+                   Rolling, Window, PeriodicDataFrame, Random, GroupBy)
 from .aggregations import Aggregation

--- a/streamz/dataframe/core.py
+++ b/streamz/dataframe/core.py
@@ -820,7 +820,7 @@ def random_datablock(last, now, **kwargs):
         Current time.
     freq: timedelta, optional
         The time interval between individual records to be returned.
-        For good throughput, should be much smaller than the 
+        For good throughput, should be much smaller than the
         interval at which this function is called.
 
     Returns a pd.DataFrame with random values where:
@@ -847,8 +847,8 @@ class PeriodicDataFrame(DataFrame):
     ----------
     datafn: callable
         Callback function accepting **kwargs and returning a
-        pd.DataFrame.  kwargs will include at least 
-        'last' (time.time() datafn was last invoked), and 
+        pd.DataFrame.  kwargs will include at least
+        'last' (time.time() datafn was last invoked), and
         'now' (current time.time()).
     interval: timedelta
         The time interval between new dataframes.
@@ -907,7 +907,7 @@ class Random(PeriodicDataFrame):
     """PeriodicDataFrame providing random values by default
 
     Accepts same parameters as PeriodicDataFrame.
-    Useful mainly for examples and docs. 
+    Useful mainly for examples and docs.
 
     Example
     -------

--- a/streamz/dataframe/core.py
+++ b/streamz/dataframe/core.py
@@ -807,6 +807,7 @@ def random_datapoint(_):
     return pd.DataFrame(
         {'a': np.random.random(1)}, index=[pd.Timestamp.now()])
 
+
 def random_datablock(tup):
     """Example of querying over a range since last update"""
     last, now, freq = tup
@@ -818,6 +819,7 @@ def random_datablock(tup):
                        'z': np.random.normal(0, 1, size=len(index))},
                       index=index)
     return df
+
 
 class PeriodicDataFrame(DataFrame):
     """A streaming dataframe using the Tornado ioloop to poll a callback fn
@@ -895,7 +897,7 @@ class Random(PeriodicDataFrame):
     def __init__(self, freq='100ms', interval='500ms', dask=False):
         super(Random, self).__init__(freq, interval, dask, datafn=random_datablock)
 
-            
+
 _stream_types['streaming'].append((is_dataframe_like, DataFrame))
 _stream_types['streaming'].append((is_index_like, Index))
 _stream_types['streaming'].append((is_series_like, Series))

--- a/streamz/dataframe/core.py
+++ b/streamz/dataframe/core.py
@@ -841,7 +841,7 @@ def random_datablock(last, now, **kwargs):
 
 
 class PeriodicDataFrame(DataFrame):
-    """A streaming dataframe using the Tornado ioloop to poll a callback fn
+    """A streaming dataframe using the asyncio ioloop to poll a callback fn
 
     Parameters
     ----------

--- a/streamz/tests/test_batch.py
+++ b/streamz/tests/test_batch.py
@@ -41,11 +41,11 @@ def test_periodic_dataframes():
     pd = pytest.importorskip('pandas')
     from streamz.dataframe import PeriodicDataFrame
     from streamz.dataframe.core import random_datapoint
-    df = random_datapoint()
+    df = random_datapoint(now=pd.Timestamp.now())
     assert len(df) == 1
 
-    def callback(**kwargs):
-        return pd.DataFrame(dict(x=50, index=[pd.Timestamp.now()]))
+    def callback(now, **kwargs):
+        return pd.DataFrame(dict(x=50, index=[now]))
 
     df = PeriodicDataFrame(callback, interval='20ms')
     assert df.tail(0).x == 50

--- a/streamz/tests/test_batch.py
+++ b/streamz/tests/test_batch.py
@@ -42,13 +42,13 @@ def test_periodic_dataframes():
     from streamz.dataframe import PeriodicDataFrame
     from streamz.dataframe.core import random_datapoint
     df = random_datapoint()
-    assert len(df)==1
-    
+    assert len(df) == 1
+
     def callback(**kwargs):
         return pd.DataFrame(dict(x=50, index=[pd.Timestamp.now()]))
 
     df = PeriodicDataFrame(callback, interval='20ms')
-    assert df.tail(0).x==50
+    assert df.tail(0).x == 50
     df.stop()
 
 

--- a/streamz/tests/test_batch.py
+++ b/streamz/tests/test_batch.py
@@ -37,6 +37,21 @@ def test_dataframes():
     assert result.z.tolist() == [3 * i for i in range(10)]
 
 
+def test_periodic_dataframes():
+    pd = pytest.importorskip('pandas')
+    from streamz.dataframe import PeriodicDataFrame
+    from streamz.dataframe.core import random_datapoint
+    df = random_datapoint()
+    assert len(df)==1
+    
+    def callback(**kwargs):
+        return pd.DataFrame(dict(x=50, index=[pd.Timestamp.now()]))
+
+    df = PeriodicDataFrame(callback, interval='20ms')
+    assert df.tail(0).x==50
+    df.stop()
+
+
 def test_filter():
     a = Batch()
     f = a.filter(lambda x: x % 2 == 0)


### PR DESCRIPTION
This PR adds a PeriodicDataFrame that is essentially just streamz.dataframe.Random but with the callback parameterized so that users can supply their own function. The resulting object allows essentially arbitrary batched or non-batched callbacks without a user having to understand any of the complicated streamz logic; they just write a simple function and get back a periodically accumulating or updating streaming dataframe.

You can run a reproducible example of roughly this code by downloading the project at [bit.ly/streaming_hvplot](https://bit.ly/streaming_hvplot).  In a few lines that don't involve any tricky concepts (skip to the line starting "import pandas as pd, time, psutil" in tornado_stream.ipynb), users can make an entire streaming viz app with custom calls to system libraries to get real-time data. Following the main streamz API to do this is daunting for most users, but it's trivial with PeriodicDataFrame.

Open questions:
1. Is it cleaner if the callback takes **kwargs, so that we can add additional information there later without breaking existing callbacks?  I don't have any such information in mind now, but one never does...
2. The "freq" parameter is actually an interval (a time duration), not a frequency (cycles per time duration). Not sure if it's worth renaming, since it was already in Random.
3. Random was marked "experimental", but it's being used as an example in several external frameworks, including Panel and hvPlot. I've kept it; it adds only a few lines and no extra complexity.
4. The name could also be TornadoPeriodicDataFrame, because it's specific to the Tornado IOLoop, but I think that would likely just confuse a user that would want this convenient function.