### PR TITLE
Add refresh_cycles parameter to from_kafka_batched to accommodate adding Kafka topic partitions on the fly.

### DIFF
--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -290,7 +290,7 @@ def test_kafka_batch_npartitions():
         stream3.upstream.stopped = True
 
 
-def test_kafka_refresh_cycles():
+def test_kafka_check_npartitions_every():
     j1 = random.randint(0, 10000)
     ARGS = {'bootstrap.servers': 'localhost:9092',
             'group.id': 'streamz-test%i' % j1,
@@ -315,7 +315,7 @@ def test_kafka_refresh_cycles():
 
         stream = Stream.from_kafka_batched(TOPIC, ARGS,
                                            asynchronous=True,
-                                           refresh_cycles=1,
+                                           check_npartitions_every=1,
                                            poll_interval='2s')
         out = stream.gather().sink_to_list()
         stream.start()

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -290,7 +290,7 @@ def test_kafka_batch_npartitions():
         stream3.upstream.stopped = True
 
 
-def test_kafka_check_npartitions_every():
+def test_kafka_refresh_partitions():
     j1 = random.randint(0, 10000)
     ARGS = {'bootstrap.servers': 'localhost:9092',
             'group.id': 'streamz-test%i' % j1,
@@ -315,7 +315,7 @@ def test_kafka_check_npartitions_every():
 
         stream = Stream.from_kafka_batched(TOPIC, ARGS,
                                            asynchronous=True,
-                                           check_npartitions_every=1,
+                                           refresh_partitions=True,
                                            poll_interval='2s')
         out = stream.gather().sink_to_list()
         stream.start()

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -336,7 +336,8 @@ def test_kafka_refresh_cycles():
         kafka.flush()
         time.sleep(5)
 
-        assert (len(out) == 4 and (len(out[2]) + len(out[3])) == 10)
+        assert (len(out) == 4 and (len(out[2]) + len(out[3])) == 10
+                and out[3][4] == b'value-19')
         stream.upstream.stopped = True
 
 

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -298,12 +298,12 @@ def test_kafka_refresh_cycles():
             'auto.offset.reset': 'earliest'}
     with kafka_service() as kafka:
         kafka, TOPIC = kafka
-        TOPIC = "test-partitions"
+        TOPIC = "test-refresh-partitions"
         subprocess.call(shlex.split("docker exec streamz-kafka "
                                     "/opt/kafka_2.11-0.10.1.0/bin/kafka-topics.sh "
                                     "--create --zookeeper localhost:2181 "
                                     "--replication-factor 1 --partitions 2 "
-                                    "--topic test-partitions"))
+                                    "--topic test-refresh-partitions"))
         time.sleep(2)
 
         for i in range(10):
@@ -325,7 +325,7 @@ def test_kafka_refresh_cycles():
         subprocess.call(shlex.split("docker exec streamz-kafka "
                                     "/opt/kafka_2.11-0.10.1.0/bin/kafka-topics.sh "
                                     "--alter --zookeeper localhost:2181 "
-                                    "--topic test-partitions --partitions 4"))
+                                    "--topic test-refresh-partitions --partitions 4"))
         time.sleep(5)
 
         for i in range(10,20):


### PR DESCRIPTION
Streamz should be able to handle addition of Kafka topic partitions on the fly. The `refresh_cycles` parameter polls Kafka every `N` cycles to get the latest Kafka partition metadata and accommodates any added partitions on the fly. 

[Some more discussion in #358]