### PR TITLE
Fix code blocks in quickstart list

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -84,14 +84,18 @@ environment but rather for experimentation, learning, or new feature development
 Its most common use would be to interact with the streamz example jupyter notebooks. Lets walk through the steps needed for this.
 
 - Build the Docker container
-.. code-block:: bash
-$ docker/build.sh
-- Run the Docker container
-.. code-block:: bash
-$ docker/run.sh
-- Interact with Jupyter Lab on the container in your browser at `JUPYTER_LAB`_.
-.. JUPYTER_LAB: http://localhost:8888/
 
+  .. code-block:: bash
+
+      $ docker/build.sh
+
+- Run the Docker container
+
+  .. code-block:: bash
+
+      $ docker/run.sh
+
+- Interact with Jupyter Lab on the container in your browser at `http://localhost:8888/ <http://localhost:8888/>`_.
 
 
 Related Work


### PR DESCRIPTION
See problem: https://streamz.readthedocs.io/en/latest/#quickstart

![screenshot of current readthedocs](https://user-images.githubusercontent.com/426784/98015247-91b3a180-1dca-11eb-953f-0a1d3bd4578e.png)

Fixed:

![screenshot of fixed version](https://user-images.githubusercontent.com/426784/98015082-69c43e00-1dca-11eb-94a9-94ae05a7cb25.png)