### PR TITLE
A simple plugin system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - conda update conda
 
   # Install dependencies
-  - conda env create --name test-streamz --file ./conda/environments/streamz_dev.yml
+  - travis_wait 30 conda env create --name test-streamz --file ./conda/environments/streamz_dev.yml
   - source activate test-streamz
 
   - python setup.py install

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -122,3 +122,4 @@ data streaming systems like `Apache Flink <https://flink.apache.org/>`_,
    collections-api.rst
    async.rst
    plotting.rst
+   plugins.rst

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -1,0 +1,102 @@
+Plugins
+=======
+
+In addition to using ``@Stream.register_api()`` decorator, custom stream nodes can
+be added to Streamz by installing 3rd-party Python packages.
+
+
+Known plugins
+-------------
+
+Extras
+++++++
+
+These plugins are supported by the Streamz community and can be installed as extras,
+e.g. ``pip install streamz[kafka]``.
+
+There are no plugins here yet, but hopefully soon there will be.
+
+.. only:: comment
+    ================= ======================================================
+    Extra name        Description
+    ================= ======================================================
+    ``files``         Advanced filesystem operations: listening for new
+                    files in a directory, writing to multiple files etc.
+    ``kafka``         Reading from and writing to Kafka topics.
+    ================= ======================================================
+
+
+Entry points
+------------
+
+Plugins register themselves with Streamz by using ``entry_points`` argument
+in ``setup.py``:
+
+.. code-block:: Python
+
+    # setup.py
+
+    from setuptools import setup
+
+    setup(
+        name="streamz_example_plugin",
+        version="0.0.1",
+        entry_points={
+            "streamz.nodes": [
+                "repeat = streamz_example_plugin:RepeatNode"
+            ]
+        }
+    )
+
+In this example, ``RepeatNode`` class will be imported from
+``streamz_example_plugin`` package and will be available as ``Stream.repeat``.
+In practice, class name and entry point name (the part before ``=`` in entry point
+definition) are usually the same, but they `can` be different.
+
+Different kinds of add-ons go into different entry point groups:
+
+=========== ======================= =====================
+ Node type   Required parent class   Entry point group
+=========== ======================= =====================
+ Source      ``streamz.Source``      ``streamz.sources``
+ Node        ``streamz.Stream``      ``streamz.nodes``
+ Sink        ``streamz.Stream``      ``streamz.sinks``
+=========== ======================= =====================
+
+
+Lazy loading
+++++++++++++
+
+Streamz will attach methods from existing plugins to the ``Stream`` class when it's
+imported, but actual classes will be loaded only when the corresponding ``Stream``
+method is first called. Streamz will also validate the loaded class before attaching it
+and will raise an appropriate exception if validation fails.
+
+
+Reference implementation
+------------------------
+
+Let's look at how stream nodes can be implemented.
+
+.. code-block:: Python
+
+    # __init__.py
+
+    from tornado import gen
+    from streamz import Stream
+
+
+    class RepeatNode(Stream):
+
+        def __init__(self, upstream, n, **kwargs):
+            super().__init__(upstream, ensure_io_loop=True, **kwargs)
+            self._n = n
+
+        @gen.coroutine
+        def update(self, x, who=None, metadata=None):
+            for _ in range(self._n):
+                yield self._emit(x, metadata=metadata)
+
+As you can see, implementation is the same as usual, but there's no
+``@Stream.register_api()`` — Streamz will take care of that when loading the plugin.
+It will still work if you add the decorator, but you don't have to.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ tornado
 toolz
 zict
 six
+setuptools

--- a/streamz/__init__.py
+++ b/streamz/__init__.py
@@ -3,6 +3,10 @@ from __future__ import absolute_import, division, print_function
 from .core import *
 from .graph import *
 from .sources import *
+from .plugins import load_plugins
+
+load_plugins()
+
 try:
     from .dask import DaskStream, scatter
 except ImportError:

--- a/streamz/__init__.py
+++ b/streamz/__init__.py
@@ -5,7 +5,7 @@ from .graph import *
 from .sources import *
 from .plugins import load_plugins
 
-load_plugins()
+load_plugins(Stream)
 
 try:
     from .dask import DaskStream, scatter

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -312,7 +312,7 @@ class Stream(object):
                 raise TypeError(
                     f"Error loading {entry_point.name} "
                     f"from module {entry_point.module_name}: "
-                    f"{entry_point.cls.__name__} must be a subclass of Stream"
+                    f"{node.__class__.__name__} must be a subclass of Stream"
                 )
             cls.register_api(
                 modifier=modifier, attribute_name=entry_point.name

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -307,6 +307,7 @@ class Stream(object):
     @classmethod
     def register_plugin_entry_point(cls, entry_point, modifier=identity):
         def stub(*args, **kwargs):
+            """ Entrypoints-based streamz plugin. Will be loaded on first call. """
             node = entry_point.load()
             if not issubclass(node, Stream):
                 raise TypeError(
@@ -314,9 +315,10 @@ class Stream(object):
                     f"from module {entry_point.module_name}: "
                     f"{node.__class__.__name__} must be a subclass of Stream"
                 )
-            cls.register_api(
-                modifier=modifier, attribute_name=entry_point.name
-            )(node)
+            if getattr(cls, entry_point.name).__name__ == "stub":
+                cls.register_api(
+                    modifier=modifier, attribute_name=entry_point.name
+                )(node)
             return node(*args, **kwargs)
         cls.register_api(modifier=modifier, attribute_name=entry_point.name)(stub)
 

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -306,6 +306,12 @@ class Stream(object):
 
     @classmethod
     def register_plugin_entry_point(cls, entry_point, modifier=identity):
+        if hasattr(cls, entry_point.name):
+            raise ValueError(
+                f"Can't add {entry_point.name} from {entry_point.module_name} "
+                f"to {cls.__name__}: duplicate method name."
+            )
+
         def stub(*args, **kwargs):
             """ Entrypoints-based streamz plugin. Will be loaded on first call. """
             node = entry_point.load()

--- a/streamz/dataframe/tests/test_dataframes.py
+++ b/streamz/dataframe/tests/test_dataframes.py
@@ -1008,9 +1008,9 @@ def test_windowed_groupby_aggs_with_start_state(stream):
     out_df1 = pd.DataFrame({'name':['Alice', 'Bob', 'Linda', 'Tom'], 'amount':[50.0, 550.0, 100.0, 150.0]})
     assert_eq(output1[-1][1].reset_index(), out_df1)
 
-    
+
 def test_dir(stream):
     example = pd.DataFrame({'name': [], 'amount': []})
     sdf = DataFrame(stream, example=example)
     assert 'name' in dir(sdf)
-    assert 'amount' in dir(sdf)    
+    assert 'amount' in dir(sdf)

--- a/streamz/plugins.py
+++ b/streamz/plugins.py
@@ -1,6 +1,10 @@
 import pkg_resources
 
 
-def load_plugins():
-    for entry_point in pkg_resources.iter_entry_points("streamz.plugins"):
-        entry_point.load()
+def load_plugins(cls):
+    for entry_point in pkg_resources.iter_entry_points("streamz.sources"):
+        cls.register_plugin_entrypoint(entry_point, staticmethod)
+    for entry_point in pkg_resources.iter_entry_points("streamz.nodes"):
+        cls.register_plugin_entrypoint(entry_point)
+    for entry_point in pkg_resources.iter_entry_points("streamz.sinks"):
+        cls.register_plugin_entrypoint(entry_point)

--- a/streamz/plugins.py
+++ b/streamz/plugins.py
@@ -1,0 +1,6 @@
+import pkg_resources
+
+
+def load_plugins():
+    for entry_point in pkg_resources.iter_entry_points("streamz.plugins"):
+        entry_point.load()

--- a/streamz/plugins.py
+++ b/streamz/plugins.py
@@ -1,10 +1,22 @@
+import warnings
+
 import pkg_resources
+
+
+def try_register(cls, entry_point, *modifier):
+    try:
+        cls.register_plugin_entry_point(entry_point, *modifier)
+    except ValueError:
+        warnings.warn(
+            f"Can't add {entry_point.name} from {entry_point.module_name}: "
+            "name collision with existing stream node."
+        )
 
 
 def load_plugins(cls):
     for entry_point in pkg_resources.iter_entry_points("streamz.sources"):
-        cls.register_plugin_entry_point(entry_point, staticmethod)
+        try_register(cls, entry_point, staticmethod)
     for entry_point in pkg_resources.iter_entry_points("streamz.nodes"):
-        cls.register_plugin_entry_point(entry_point)
+        try_register(cls, entry_point)
     for entry_point in pkg_resources.iter_entry_points("streamz.sinks"):
-        cls.register_plugin_entry_point(entry_point)
+        try_register(cls, entry_point)

--- a/streamz/plugins.py
+++ b/streamz/plugins.py
@@ -3,8 +3,8 @@ import pkg_resources
 
 def load_plugins(cls):
     for entry_point in pkg_resources.iter_entry_points("streamz.sources"):
-        cls.register_plugin_entrypoint(entry_point, staticmethod)
+        cls.register_plugin_entry_point(entry_point, staticmethod)
     for entry_point in pkg_resources.iter_entry_points("streamz.nodes"):
-        cls.register_plugin_entrypoint(entry_point)
+        cls.register_plugin_entry_point(entry_point)
     for entry_point in pkg_resources.iter_entry_points("streamz.sinks"):
-        cls.register_plugin_entrypoint(entry_point)
+        cls.register_plugin_entry_point(entry_point)

--- a/streamz/tests/test_plugins.py
+++ b/streamz/tests/test_plugins.py
@@ -53,3 +53,17 @@ def test_register_plugin_entry_point_raises():
 
     with pytest.raises(TypeError):
         Stream.test()
+
+
+def test_register_plugin_entry_point_already_registered():
+    @Stream.register_api()
+    class test(Stream):
+        pass
+
+    entry_point = MockEntryPoint("test_double", test, "test_module")
+
+    Stream.register_plugin_entry_point(entry_point)
+
+    assert Stream.test_double.__name__ == "stub"
+    Stream.test_double()
+    assert Stream.test_double.__name__ == "test"

--- a/streamz/tests/test_plugins.py
+++ b/streamz/tests/test_plugins.py
@@ -1,0 +1,38 @@
+from streamz.sources import Source
+from streamz import Stream
+
+
+class MockEntryPoint:
+
+    def __init__(self, name, cls):
+        self.name = name
+        self.cls = cls
+
+    def load(self):
+        return self.cls
+
+
+def test_register_plugin_entry_point():
+    class test(Stream):
+        pass
+
+    entry_point = MockEntryPoint("test_node", test)
+    Stream.register_plugin_entry_point(entry_point)
+
+    assert Stream.test_node.__name__ == "stub"
+
+    Stream().test_node()
+
+    assert Stream.test_node.__name__ == "test"
+
+
+def test_register_plugin_entry_point_modifier():
+    class test(Source):
+        pass
+
+    entry_point = MockEntryPoint("from_test", test)
+    Stream.register_plugin_entry_point(entry_point, staticmethod)
+
+    Stream.from_test()
+
+    assert Stream.from_test.__self__ is Stream

--- a/streamz/tests/test_plugins.py
+++ b/streamz/tests/test_plugins.py
@@ -41,7 +41,7 @@ def test_register_plugin_entry_point_modifier():
     assert inspect.isfunction(Stream().from_test)
 
 
-def test_register_plugin_entry_point_raises():
+def test_register_plugin_entry_point_raises_type():
     class invalid_node:
         pass
 
@@ -51,3 +51,10 @@ def test_register_plugin_entry_point_raises():
 
     with pytest.raises(TypeError):
         Stream.test()
+
+
+def test_register_plugin_entry_point_raises_duplicate_name():
+    entry_point = MockEntryPoint("map", None)
+
+    with pytest.raises(ValueError):
+        Stream.register_plugin_entry_point(entry_point)

--- a/streamz/tests/test_plugins.py
+++ b/streamz/tests/test_plugins.py
@@ -1,38 +1,55 @@
-from streamz.sources import Source
-from streamz import Stream
+import pytest
+from streamz import Source, Stream
 
 
 class MockEntryPoint:
 
-    def __init__(self, name, cls):
+    def __init__(self, name, cls, module_name=None):
         self.name = name
         self.cls = cls
+        self.module_name = module_name
 
     def load(self):
         return self.cls
 
 
 def test_register_plugin_entry_point():
-    class test(Stream):
+    class test_stream(Stream):
         pass
 
-    entry_point = MockEntryPoint("test_node", test)
+    entry_point = MockEntryPoint("test_node", test_stream)
     Stream.register_plugin_entry_point(entry_point)
 
     assert Stream.test_node.__name__ == "stub"
 
     Stream().test_node()
 
-    assert Stream.test_node.__name__ == "test"
+    assert Stream.test_node.__name__ == "test_stream"
 
 
 def test_register_plugin_entry_point_modifier():
-    class test(Source):
+    class test_source(Source):
         pass
 
-    entry_point = MockEntryPoint("from_test", test)
-    Stream.register_plugin_entry_point(entry_point, staticmethod)
+    def modifier(fn):
+        fn.__name__ = 'modified_name'
+        return staticmethod(fn)
+
+    entry_point = MockEntryPoint("from_test", test_source)
+    Stream.register_plugin_entry_point(entry_point, modifier)
 
     Stream.from_test()
 
-    assert Stream.from_test.__self__ is Stream
+    assert Stream.from_test.__name__ == "modified_name"
+
+
+def test_register_plugin_entry_point_raises():
+    class invalid_node:
+        pass
+
+    entry_point = MockEntryPoint("test", invalid_node, "test_module.test")
+
+    Stream.register_plugin_entry_point(entry_point)
+
+    with pytest.raises(TypeError):
+        Stream.test()

--- a/streamz/tests/test_plugins.py
+++ b/streamz/tests/test_plugins.py
@@ -1,3 +1,5 @@
+import inspect
+
 import pytest
 from streamz import Source, Stream
 
@@ -31,16 +33,12 @@ def test_register_plugin_entry_point_modifier():
     class test_source(Source):
         pass
 
-    def modifier(fn):
-        fn.__name__ = 'modified_name'
-        return staticmethod(fn)
-
     entry_point = MockEntryPoint("from_test", test_source)
-    Stream.register_plugin_entry_point(entry_point, modifier)
+    Stream.register_plugin_entry_point(entry_point, staticmethod)
 
     Stream.from_test()
 
-    assert Stream.from_test.__name__ == "modified_name"
+    assert inspect.isfunction(Stream().from_test)
 
 
 def test_register_plugin_entry_point_raises():
@@ -53,17 +51,3 @@ def test_register_plugin_entry_point_raises():
 
     with pytest.raises(TypeError):
         Stream.test()
-
-
-def test_register_plugin_entry_point_already_registered():
-    @Stream.register_api()
-    class test(Stream):
-        pass
-
-    entry_point = MockEntryPoint("test_double", test, "test_module")
-
-    Stream.register_plugin_entry_point(entry_point)
-
-    assert Stream.test_double.__name__ == "stub"
-    Stream.test_double()
-    assert Stream.test_double.__name__ == "test"


### PR DESCRIPTION
Right now, if I need to add my own custom stream nodes, I have to do this:

```py
import mypackage.streamz_extras  # noqa: F401
```

It would be nice to have a way to distribute additional functionality as separate packages that can just be installed via pip. This can be done with entry_points, similar to the way it works in airflow. This is a super bare-bones implementation of this mechanism. Check out https://github.com/roveo/streamz_example_plugin for an example of a plugin.

Problems:
- this should be tested, but I have no idea how, short of shipping the code for example plugin with tests
- plugged-in classes should be checked for validity in some way. I can add a simple check e.g. `isinstance(plugin, Stream)`, but there is probably something else I haven't thought of