### PR TITLE
Add nodes that unique their buffers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ log
 .cache/
 .ipynb_checkpoints/
 .vscode
+.python-version

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -1324,7 +1324,7 @@ class timed_window_unique(Stream):
     ()
 
     Get unique elements in a window by (string) length, keeping just the last occurrence:
-    >>> stream = source.timed_window_unique(interval=1.0, key=len, keep="first")
+    >>> stream = source.timed_window_unique(interval=1.0, key=len, keep="last")
     >>> for ele in ["f", "b", "fo", "ba", "foo", "bar"]:
     ...     source.emit(ele)
     ()

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -1280,9 +1280,9 @@ class timed_window_unique(Stream):
     key: Union[Hashable, Callable[[Any], Hashable]]
         Callable that accepts a stream element and returns a unique, hashable
         representation of the incoming data (``key(x)``), or a hashable that gets
-        the corresponding value of a stream element (``x[key]``). For example,
-        ``key=lambda x: x["a"]`` would allow only elements with unique ``"a"`` values
-        to pass through.
+        the corresponding value of a stream element (``x[key]``). For example, both
+        ``key=lambda x: x["a"]`` and ``key="a"`` would allow only elements with unique
+        ``"a"`` values to pass through.
 
         .. note:: By default, we simply use the element object itself as the key,
             so that object must be hashable. If that's not the case, a non-default
@@ -1298,39 +1298,37 @@ class timed_window_unique(Stream):
     Examples
     --------
     >>> source = Stream()
-    >>> stream = source.timed_window_unique(interval=2, keep="first").sink(print)
-    >>> eles = [1, 2, 1, 3, 1, 3, 3, 2]
-    >>> for ele in eles:
+
+    Get unique hashable elements in a window, keeping just the first occurrence:
+    >>> stream = source.timed_window_unique(interval=1.0, keep="first").sink(print)
+    >>> for ele in [1, 2, 3, 3, 2, 1]:
     ...     source.emit(ele)
-    ...     time.sleep(0.6)
     ()
     (1, 2, 3)
-    (1, 3)
-    (2,)
     ()
 
-    >>> source = Stream()
-    >>> stream = source.timed_window_unique(interval=2, keep="last").sink(print)
-    >>> eles = [1, 2, 1, 3, 1, 3, 3, 2]
-    >>> for ele in eles:
+    Get unique hashable elements in a window, keeping just the last occurrence:
+    >>> stream = source.timed_window_unique(interval=1.0, keep="last").sink(print)
+    >>> for ele in [1, 2, 3, 3, 2, 1]:
     ...     source.emit(ele)
-    ...     time.sleep(0.6)
     ()
-    (2, 1, 3)
-    (1, 3)
-    (2,)
+    (3, 2, 1)
     ()
 
-    >>> source = Stream()
-    >>> stream = source.timed_window_unique(interval=2, key=lambda x: len(x), keep="last").sink(print)
-    >>> eles = ["f", "fo", "f", "foo", "f", "foo", "foo", "fo"]
-    >>> for ele in eles:
+    Get unique elements in a window by (string) length, keeping just the first occurrence:
+    >>> stream = source.timed_window_unique(interval=1.0, key=len, keep="first")
+    >>> for ele in ["f", "b", "fo", "ba", "foo", "bar"]:
     ...     source.emit(ele)
-    ...     time.sleep(0.6)
     ()
-    ('fo', 'f', 'foo')
-    ('f', 'foo')
-    ('fo',)
+    ('f', 'fo', 'foo')
+    ()
+
+    Get unique elements in a window by (string) length, keeping just the last occurrence:
+    >>> stream = source.timed_window_unique(interval=1.0, key=len, keep="first")
+    >>> for ele in ["f", "b", "fo", "ba", "foo", "bar"]:
+    ...     source.emit(ele)
+    ()
+    ('b', 'ba', 'bar')
     ()
     """
     _graphviz_shape = "octagon"

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -1268,6 +1268,126 @@ class timed_window(Stream):
 
 
 @Stream.register_api()
+class timed_window_unique(Stream):
+    """
+    Emit a group of elements with unique keys every ``interval`` seconds.
+
+    Parameters
+    ----------
+    interval: Union[int, str]
+        Number of seconds over which to group elements, or a ``pandas``-style
+        duration string that can be converted into seconds.
+    key: Union[Hashable, Callable[[Any], Hashable]]
+        Callable that accepts a stream element and returns a unique, hashable
+        representation of the incoming data (``key(x)``), or a hashable that gets
+        the corresponding value of a stream element (``x[key]``). For example,
+        ``key=lambda x: x["a"]`` would allow only elements with unique ``"a"`` values
+        to pass through.
+
+        .. note:: By default, we simply use the element object itself as the key,
+            so that object must be hashable. If that's not the case, a non-default
+            key must be provided.
+
+    keep: str
+        Which element to keep in the case that a unique key is already found
+        in the group. If "first", keep element from the first occurrence of a given
+        key; if "last", keep element from the most recent occurrence. Note that
+        relative ordering of *elements* is preserved in the data passed through,
+        and not ordering of *keys*.
+
+    Examples
+    --------
+    >>> source = Stream()
+    >>> stream = source.timed_window_unique(interval=2, keep="first").sink(print)
+    >>> eles = [1, 2, 1, 3, 1, 3, 3, 2]
+    >>> for ele in eles:
+    ...     source.emit(ele)
+    ...     time.sleep(0.6)
+    ()
+    (1, 2, 3)
+    (1, 3)
+    (2,)
+    ()
+
+    >>> source = Stream()
+    >>> stream = source.timed_window_unique(interval=2, keep="last").sink(print)
+    >>> eles = [1, 2, 1, 3, 1, 3, 3, 2]
+    >>> for ele in eles:
+    ...     source.emit(ele)
+    ...     time.sleep(0.6)
+    ()
+    (2, 1, 3)
+    (1, 3)
+    (2,)
+    ()
+
+    >>> source = Stream()
+    >>> stream = source.timed_window_unique(interval=2, key=lambda x: len(x), keep="last").sink(print)
+    >>> eles = ["f", "fo", "f", "foo", "f", "foo", "foo", "fo"]
+    >>> for ele in eles:
+    ...     source.emit(ele)
+    ...     time.sleep(0.6)
+    ()
+    ('fo', 'f', 'foo')
+    ('f', 'foo')
+    ('fo',)
+    ()
+    """
+    _graphviz_shape = "octagon"
+
+    def __init__(
+        self,
+        upstream,
+        interval: Union[int, str],
+        key: Union[Hashable, Callable[[Any], Hashable]] = identity,
+        keep: str = "first",  # Literal["first", "last"]
+        **kwargs
+    ):
+        self.interval = convert_interval(interval)
+        self.key = key
+        self.keep = keep
+        self._buffer = {}
+        self._metadata_buffer = {}
+        self.last = gen.moment
+        Stream.__init__(self, upstream, ensure_io_loop=True, **kwargs)
+        self.loop.add_callback(self.cb)
+
+    def _get_key(self, x):
+        if callable(self.key):
+            return self.key(x)
+        else:
+            return x[self.key]
+
+    def update(self, x, who=None, metadata=None):
+        self._retain_refs(metadata)
+        y = self._get_key(x)
+        if self.keep == "last":
+            # remove key if already present so that emitted value
+            # will reflect elements' actual relative ordering
+            self._buffer.pop(y, None)
+            self._metadata_buffer.pop(y, None)
+            self._buffer[y] = x
+            self._metadata_buffer[y] = metadata
+        else:  # self.keep == "first"
+            if y not in self._buffer:
+                self._buffer[y] = x
+                self._metadata_buffer[y] = metadata
+        return self.last
+
+    @gen.coroutine
+    def cb(self):
+        while True:
+            result, self._buffer = tuple(self._buffer.values()), {}
+            metadata_result, self._metadata_buffer = list(self._metadata_buffer.values()), {}
+            # TODO: figure out why metadata_result is handled differently here...
+            m = [m for ml in metadata_result for m in ml]
+            self.last = self._emit(result, m)
+            self._release_refs(m)
+            yield self.last
+            yield gen.sleep(self.interval)
+
+
+@Stream.register_api()
 class delay(Stream):
     """ Add a time delay to results """
     _graphviz_shape = 'octagon'

--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -164,6 +164,43 @@ def test_partition():
     assert L == [(0, 1), (2, 3), (4, 5), (6, 7), (8, 9)]
 
 
+@pytest.mark.parametrize(
+    "n,key,keep,elements,exp_result",
+    [
+        (3, sz.identity, "first", [1, 2, 1, 3, 1, 3, 3, 2], [(1, 2, 3), (1, 3, 2)]),
+        (3, sz.identity, "last", [1, 2, 1, 3, 1, 3, 3, 2], [(2, 1, 3), (1, 3, 2)]),
+        (
+            3,
+            len,
+            "last",
+            ["f", "fo", "f", "foo", "f", "foo", "foo", "fo"],
+            [("fo", "f", "foo"), ("f", "foo", "fo")],
+        ),
+        (
+            2,
+            "id",
+            "first",
+            [{"id": 0, "foo": "bar"}, {"id": 0, "foo": "baz"}, {"id": 1, "foo": "bat"}],
+            [({"id": 0, "foo": "bar"}, {"id": 1, "foo": "bat"})],
+        ),
+        (
+            2,
+            "id",
+            "last",
+            [{"id": 0, "foo": "bar"}, {"id": 0, "foo": "baz"}, {"id": 1, "foo": "bat"}],
+            [({"id": 0, "foo": "baz"}, {"id": 1, "foo": "bat"})],
+        ),
+    ]
+)
+def test_partition_unique(n, key, keep, elements, exp_result):
+    source = Stream()
+    L = source.partition_unique(n, key, keep).sink_to_list()
+    for ele in elements:
+        source.emit(ele)
+
+    assert L == exp_result
+
+
 def test_partition_timeout():
     source = Stream()
     L = source.partition(10, timeout=0.01).sink_to_list()

--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -333,6 +333,60 @@ def test_backpressure():
     assert end - start >= 0.2
 
 
+# TODO: looks like gen_test and pytest.mark.parametrize don't play nicely together:
+# TypeError: test_timed_window_unique() missing 5 required positional arguments: 'interval', 'key', 'keep', 'elements', and 'exp_result'
+# I think gen_test() needs to be modified for this to work, but unsure how
+# TODO: fix tests' exp_result values and the logic inside, once it runs without ^ error
+# @gen_test()
+# @pytest.mark.parametrize(
+#     "interval,key,keep,elements,exp_result",
+#     [
+#         (0.2, sz.identity, "first", [1, 2, 1, 3, 1, 3, 3, 2], [(1, 2, 3), (1, 3, 2)]),
+#         (0.2, sz.identity, "last", [1, 2, 1, 3, 1, 3, 3, 2], [(2, 1, 3), (1, 3, 2)]),
+#         (
+#             0.02,
+#             len,
+#             "last",
+#             ["f", "fo", "f", "foo", "f", "foo", "foo", "fo"],
+#             [("fo", "f", "foo"), ("f", "foo", "fo")],
+#         ),
+#         (
+#             0.02,
+#             "id",
+#             "first",
+#             [{"id": 0, "foo": "bar"}, {"id": 0, "foo": "baz"}, {"id": 1, "foo": "bat"}],
+#             [({"id": 0, "foo": "bar"}, {"id": 1, "foo": "bat"})],
+#         ),
+#         (
+#             0.02,
+#             "id",
+#             "last",
+#             [{"id": 0, "foo": "bar"}, {"id": 0, "foo": "baz"}, {"id": 1, "foo": "bat"}],
+#             [({"id": 0, "foo": "baz"}, {"id": 1, "foo": "bat"})],
+#         ),
+#     ]
+# )
+# def test_timed_window_unique(interval, key, keep, elements, exp_result):
+#     import pdb; pdb.set_trace()
+#     source = Stream(asynchronous=True)
+#     a = source.timed_window_unique(interval, key, keep)
+
+#     assert a.loop is IOLoop.current()
+#     L = a.sink_to_list()
+
+#     for ele in elements:
+#         yield source.emit(ele)
+#         yield gen.sleep(0.006)
+#     yield gen.sleep(a.interval)
+
+#     assert L
+#     assert all(len(x) <= 3 for x in L)
+#     assert any(len(x) >= 2 for x in L)
+
+#     yield gen.sleep(0.1)
+#     assert not L[-1]
+
+
 @gen_test()
 def test_timed_window():
     source = Stream(asynchronous=True)


### PR DESCRIPTION
Closes Issue #383 .

This PR adds `partition_unique` and `timed_window_unique()` nodes that use a key function or hashable to identify duplicate stream elements and keep only the first or last occurrence of the unique element within a given buffering period (n or interval, respectively) before emitting the unique elements in element (not key) order. There are parallels between this and recent additions to the `partition` node, but I would prefer that consideration of a more holistic framework for modifying / extending nodes via mix-ins or whatever be kept out-of-scope for this work.

There are a couple outstanding questions and to-dos:
- I use type hints in `__init__`, but I don't see them used elsewhere. Is that okay?
- Am I handling metadata correctly in `timed_window_unique()`? I was confused about what it was doing in the original `timed_window.cb()` method, and copied it blindly.
- What's the best way to test `timed_window_unique()`? It looks like the `gen_test()` decorator doesn't play nicely with `pytest.mark.parametrize()`, and I wasn't sure how to fix that.