### PR TITLE
Test for Stream() backpressure and fix

### DIFF
--- a/streamz/core.py
+++ b/streamz/core.py
@@ -483,7 +483,7 @@ class Stream(object):
             sync(self.loop, _)
 
     def update(self, x, who=None, metadata=None):
-        self._emit(x, metadata=metadata)
+        return self._emit(x, metadata=metadata)
 
     def gather(self):
         """ This is a no-op for core streamz


### PR DESCRIPTION
Resolves #378 

Turns out, coroutine isn't required to fix this, just adding `return` is enough (like in `.map`).