### PR TITLE
from_iterable source

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -51,6 +51,7 @@ Sources
 -------
 
 .. autosummary::
+   from_iterable
    filenames
    from_kafka
    from_kafka_batched
@@ -95,6 +96,7 @@ Definitions
 .. autofunction:: zip
 .. autofunction:: zip_latest
 
+.. autofunction:: from_iterable
 .. autofunction:: filenames
 .. autofunction:: from_kafka
 .. autofunction:: from_kafka_batched

--- a/streamz/sinks.py
+++ b/streamz/sinks.py
@@ -17,6 +17,10 @@ class Sink(Stream):
         super().__init__(upstream, **kwargs)
         _global_sinks.add(self)
 
+    def destroy(self):
+        super().destroy()
+        _global_sinks.remove(self)
+
 
 @Stream.register_api()
 class sink(Sink):
@@ -66,10 +70,6 @@ class sink(Sink):
             return result
         else:
             return []
-
-    def destroy(self):
-        super().destroy()
-        _global_sinks.remove(self)
 
 
 @Stream.register_api()

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -731,3 +731,36 @@ def get_message_batch_cudf(kafka_params, topic, partition, keys, low, high, time
     finally:
         consumer.close()
     return gdf
+
+
+@Stream.register_api(staticmethod)
+class from_iterable(Source):
+    """ Emits items from an iterable.
+
+    Parameters
+    ----------
+    iterable: iterable
+        An iterable to emit messages from.
+
+    Examples
+    --------
+
+    >>> source = Stream.from_iterable(range(3))
+    >>> L = source.sink_to_list()
+    >>> source.start()
+    >>> L
+    [0, 1, 2]
+    """
+
+    def __init__(self, iterable, **kwargs):
+        super().__init__(ensure_io_loop=True, **kwargs)
+        self._iterable = iterable
+
+    def start(self):
+        self.stopped = False
+        self.loop.add_callback(self._run)
+
+    @gen.coroutine
+    def _run(self):
+        for x in self._iterable:
+            yield self._emit(x)

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -763,4 +763,7 @@ class from_iterable(Source):
     @gen.coroutine
     def _run(self):
         for x in self._iterable:
+            if self.stopped:
+                break
             yield self._emit(x)
+        self.stopped = True

--- a/streamz/tests/test_sinks.py
+++ b/streamz/tests/test_sinks.py
@@ -65,6 +65,9 @@ def test_sink_destroy():
     sink = Sink(source)
     ref = weakref.ref(sink)
     sink.destroy()
+
+    assert sink not in _global_sinks
+
     del sink
 
     assert ref() is None

--- a/streamz/tests/test_sinks.py
+++ b/streamz/tests/test_sinks.py
@@ -2,7 +2,7 @@ import weakref
 
 import pytest
 from streamz import Stream
-from streamz.sinks import _global_sinks
+from streamz.sinks import _global_sinks, Sink
 from streamz.utils_test import tmpfile
 
 
@@ -62,7 +62,7 @@ def test_sink_to_textfile_closes():
 
 def test_sink_destroy():
     source = Stream()
-    sink = source.sink(lambda x: None)
+    sink = Sink(source)
     ref = weakref.ref(sink)
     sink.destroy()
     del sink

--- a/streamz/tests/test_sources.py
+++ b/streamz/tests/test_sources.py
@@ -95,3 +95,10 @@ def test_process():
     s.start()
     yield await_for(lambda: out == [b'0\n', b'1\n', b'2\n', b'3\n'], timeout=5)
     s.stop()
+
+
+def test_from_iterable():
+    source = Source.from_iterable(range(3))
+    L = source.sink_to_list()
+    source.start()
+    wait_for(lambda: L == [0, 1, 2], 0.1)


### PR DESCRIPTION
A source that emits items from any iterable.

Why this should be in core:
- useful for tests (don't need to write the for loop with emits)
- this is the most generic form of a source, in theory you can implement any source as an unbounded generator

Also previously I missed that the `.destroy()` method in sinks was defined on `sink`, not the base `Sink` class, so there's a fix for that too.