### PR TITLE
refactor and make less tornado

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -13,3 +13,4 @@ omit =
 exclude_lines =
     if __name__ == '__main__':
     pragma: no cover
+    NotImplementedError

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 # https://flake8.readthedocs.io/en/latest/user/error-codes.html
 
 # Note: there cannot be spaces after comma's here
-exclude = __init__.py, compatibility.py
+exclude = __init__.py,tests
 ignore =
     # Extra space in brackets
     E20,

--- a/streamz/compatibility.py
+++ b/streamz/compatibility.py
@@ -1,8 +1,0 @@
-import sys
-
-if sys.version_info[0] == 2:
-    from thread import get_ident as get_thread_identity
-    import __builtin__ as builtins
-else:
-    import builtins
-    from threading import get_ident as get_thread_identity

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -512,8 +512,10 @@ class Stream(object):
 
     @property
     def upstream(self):
-        if len(self.upstreams) != 1:
+        if len(self.upstreams) > 1:
             raise ValueError("Stream has multiple upstreams")
+        elif len(self.upstreams) == 0:
+            return None
         else:
             return self.upstreams[0]
 
@@ -534,6 +536,13 @@ class Stream(object):
     def remove(self, predicate):
         """ Only pass through elements for which the predicate returns False """
         return self.filter(lambda x: not predicate(x))
+
+    def stop(self):
+        """Call on any stream node to halt all upstream sources"""
+        prev, s = self.upstream, self
+        while s:
+            prev, s = s, s.upstream
+        prev.stopped = True
 
     @property
     def scan(self):

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -23,7 +23,7 @@ except ImportError:
 
 from collections.abc import Iterable
 
-from .compatibility import get_thread_identity
+from threading import get_ident as get_thread_identity
 from .orderedweakset import OrderedWeakrefSet
 
 no_default = '--no-default--'

--- a/streamz/sinks.py
+++ b/streamz/sinks.py
@@ -107,8 +107,5 @@ class sink_to_textfile(Sink):
         weakref.finalize(self, self._fp.close)
         super().__init__(upstream, **kwargs)
 
-    def __del__(self):
-        self._fp.close()
-
     def update(self, x, who=None, metadata=None):
         self._fp.write(x + self._end)

--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -5,19 +5,18 @@ import json
 import operator
 from operator import add
 import os
-from time import time, sleep
+from time import sleep
 import sys
 
 import pytest
 
-from tornado import gen
 from tornado.queues import Queue
 from tornado.ioloop import IOLoop
 
 import streamz as sz
 
-from streamz import Stream, RefCounter
-from streamz.sources import sink_to_file, PeriodicCallback
+from streamz import RefCounter
+from streamz.sources import sink_to_file
 from streamz.utils_test import (inc, double, gen_test, tmpfile, captured_logger,   # noqa: F401
         clean, await_for, metadata, wait_for)  # noqa: F401
 from distributed.utils_test import loop   # noqa: F401
@@ -421,7 +420,7 @@ def test_timed_window_ref_counts():
 @gen_test()
 def test_timed_window_metadata():
     source = Stream()
-    L = metadata(source.timed_window(0.01)).sink_to_list()
+    L = metadata(source.timed_window(0.06)).sink_to_list()
 
     source.emit(0)
     source.emit(1, metadata=[{'v': 1}])
@@ -482,7 +481,8 @@ def test_sink_to_file():
 @gen_test()
 def test_counter():
     counter = itertools.count()
-    source = PeriodicCallback(lambda: next(counter), 0.001, asynchronous=True)
+    source = Stream.from_periodic(lambda: next(counter), 0.001, asynchronous=True,
+                                  start=True)
     L = source.sink_to_list()
     yield gen.sleep(0.05)
 

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -580,7 +580,7 @@ def test_kafka_checkpointing_auto_offset_reset_latest():
         stream1 = Stream.from_kafka_batched(TOPIC, ARGS, asynchronous=True)
         out1 = stream1.map(split).gather().sink_to_list()
         stream1.start()
-        wait_for(lambda: stream1.upstream.started, 10, 0.1)
+        wait_for(lambda: stream1.upstream.started, 10, period=0.1)
 
         '''
         Stream has started, so these are read.
@@ -589,7 +589,8 @@ def test_kafka_checkpointing_auto_offset_reset_latest():
             kafka.produce(TOPIC, b'value-%d' % i)
         kafka.flush()
 
-        wait_for(lambda: len(out1) == 3 and (len(out1[0]) + len(out1[1]) + len(out1[2])) == 30, 10, 0.1)
+        wait_for(lambda: len(out1) == 3 and (len(out1[0]) + len(out1[1]) + len(out1[2])) == 30,
+                 10, period=0.1)
         '''
         Stream stops but checkpoint has been created.
         '''
@@ -616,5 +617,6 @@ def test_kafka_checkpointing_auto_offset_reset_latest():
             kafka.produce(TOPIC, b'value-%d' % i)
         kafka.flush()
 
-        wait_for(lambda: len(out2) == 6 and (len(out2[3]) + len(out2[4]) + len(out2[5])) == 30, 10, 0.1)
+        wait_for(lambda: len(out2) == 6 and (len(out2[3]) + len(out2[4]) + len(out2[5])) == 30,
+                 10, period=0.1)
         stream2.upstream.stopped = True

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -116,9 +116,9 @@ def test_from_kafka():
         stream = Stream.from_kafka([TOPIC], ARGS, asynchronous=True)
         out = stream.sink_to_list()
         stream.start()
-        yield gen.sleep(0.1)  # for loop to run
+        yield gen.sleep(1.1)  # for loop to run
         for i in range(10):
-            yield gen.sleep(0.2)
+            yield gen.sleep(0.1)  # small pause ensures correct ordering
             kafka.produce(TOPIC, b'value-%d' % i)
         kafka.flush()
         # it takes some time for messages to come back out of kafka
@@ -168,7 +168,9 @@ def test_from_kafka_thread():
         stream = Stream.from_kafka([TOPIC], ARGS)
         out = stream.sink_to_list()
         stream.start()
+        yield gen.sleep(1.1)
         for i in range(10):
+            yield gen.sleep(0.1)
             kafka.produce(TOPIC, b'value-%d' % i)
         kafka.flush()
         # it takes some time for messages to come back out of kafka
@@ -231,8 +233,10 @@ def test_kafka_dask_batch(c, s, w1, w2):
             kafka.produce(TOPIC, b'value-%d' % i)
         kafka.flush()
         yield await_for(lambda: any(out), 10, period=0.2)
-        assert {'key':None, 'value':b'value-1'} in out[0]
-        stream.upstream.stopped = True
+        assert {'key': None, 'value': b'value-1'} in out[0]
+        stream.stop()
+        yield gen.sleep(0)
+        stream.upstream.upstream.consumer.close()
 
 
 def test_kafka_batch_npartitions():
@@ -551,11 +555,12 @@ def test_kafka_batch_checkpointing_async_nodes_2():
         assert committed3[1].offset == 1
 
 
+@flaky(max_runs=3, min_passes=1)
 def test_kafka_checkpointing_auto_offset_reset_latest():
-    '''
+    """
     Testing whether checkpointing works as expected with multiple topic partitions and
     with auto.offset.reset configuration set to latest (also default).
-    '''
+    """
     j = random.randint(0, 10000)
     ARGS = {'bootstrap.servers': 'localhost:9092',
             'group.id': 'streamz-test%i' % j,

--- a/streamz/tests/test_sources.py
+++ b/streamz/tests/test_sources.py
@@ -86,7 +86,6 @@ def test_http():
         requests.post('http://localhost:%i/other' % port, data=b'data2')
 
 
-#@flaky(max_runs=3, min_passes=1)
 @gen_test(timeout=60)
 def test_process():
     import sys

--- a/streamz/tests/test_sources.py
+++ b/streamz/tests/test_sources.py
@@ -1,8 +1,21 @@
+import asyncio
+import sys
+
 from flaky import flaky
 import pytest
 from streamz import Source
 from streamz.utils_test import wait_for, await_for, gen_test
 import socket
+
+
+def test_periodic():
+    s = Source.from_periodic(lambda: True)
+    l = s.sink_to_list()
+    assert s.stopped
+    s.start()
+    wait_for(lambda: l, 0.11, period=0.01)
+    wait_for(lambda: len(l) > 1, 0.11, period=0.01)
+    assert all(l)
 
 
 @flaky(max_runs=3, min_passes=1)
@@ -88,9 +101,23 @@ def test_http():
 
 @gen_test(timeout=60)
 def test_process():
-    import sys
-    import asyncio
-    cmd = ["python", "-c", "for i in range(4): print(i)"]
+    cmd = ["python", "-c", "for i in range(4): print(i, end='')"]
+    s = Source.from_process(cmd, with_end=True)
+    if sys.platform != "win32":
+        # don't know why - something with pytest and new processes
+        policy = asyncio.get_event_loop_policy()
+        watcher = asyncio.SafeChildWatcher()
+        policy.set_child_watcher(watcher)
+        watcher.attach_loop(s.loop.asyncio_loop)
+    out = s.sink_to_list()
+    s.start()
+    yield await_for(lambda: out == [b'0123'], timeout=5)
+    s.stop()
+
+
+@gen_test(timeout=60)
+def test_process_str():
+    cmd = 'python -c "for i in range(4): print(i)"'
     s = Source.from_process(cmd)
     if sys.platform != "win32":
         # don't know why - something with pytest and new processes


### PR DESCRIPTION
Following #393 , this moves some common code into Source, and takes the chance to make some of the sources async/await rather than tornado (the `loop` is still tornado running asyncio for now...). Kafka sources not touched, since they are more complex.