### PR TITLE
Pieces that occurred while working on intake-streamz

### DIFF
--- a/streamz/collection.py
+++ b/streamz/collection.py
@@ -232,6 +232,12 @@ class Streaming(OperatorMixin, core.APIRegisterMixin):
     def current_value(self):
         return self.stream.current_value
 
+    def start(self):
+        self.stream.start()
+
+    def stop(self):
+        self.stream.stop()
+
     def _ipython_display_(self, **kwargs):
         return self.stream.latest().rate_limit(
             0.5).gather()._ipython_display_(**kwargs)

--- a/streamz/collection.py
+++ b/streamz/collection.py
@@ -232,18 +232,12 @@ class Streaming(OperatorMixin, core.APIRegisterMixin):
     def current_value(self):
         return self.stream.current_value
 
-    @current_value.setter
-    def current_value(self, *args, **kwargs):
-        # this actually happens in self.stream - Streaming.emit is ignored
-        pass
-
     def _ipython_display_(self, **kwargs):
         return self.stream.latest().rate_limit(
             0.5).gather()._ipython_display_(**kwargs)
 
     def emit(self, x):
         self.verify(x)
-        self.current_value = x
         self.stream.emit(x)
 
     def verify(self, x):

--- a/streamz/collection.py
+++ b/streamz/collection.py
@@ -152,7 +152,7 @@ class OperatorMixin(object):
         return self.map_partitions(operator.xor, other, self)
 
 
-class Streaming(OperatorMixin):
+class Streaming(OperatorMixin, core.APIRegisterMixin):
     """
     Superclass for streaming collections
 
@@ -228,12 +228,22 @@ class Streaming(OperatorMixin):
 
         return "<h5>%s - elements like<h5>\n%s" % (type(self).__name__, body)
 
+    @property
+    def current_value(self):
+        return self.stream.current_value
+
+    @current_value.setter
+    def current_value(self, *args, **kwargs):
+        # this actually happens in self.stream - Streaming.emit is ignored
+        pass
+
     def _ipython_display_(self, **kwargs):
         return self.stream.latest().rate_limit(
             0.5).gather()._ipython_display_(**kwargs)
 
     def emit(self, x):
         self.verify(x)
+        self.current_value = x
         self.stream.emit(x)
 
     def verify(self, x):

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -122,7 +122,79 @@ class RefCounter:
     __repr__ = __str__
 
 
-class Stream(object):
+class APIRegisterMixin(object):
+
+    @classmethod
+    def register_api(cls, modifier=identity, attribute_name=None):
+        """ Add callable to Stream API
+
+        This allows you to register a new method onto this class.  You can use
+        it as a decorator.::
+
+            >>> @Stream.register_api()
+            ... class foo(Stream):
+            ...     ...
+
+            >>> Stream().foo(...)  # this works now
+
+        It attaches the callable as a normal attribute to the class object.  In
+        doing so it respects inheritance (all subclasses of Stream will also
+        get the foo attribute).
+
+        By default callables are assumed to be instance methods.  If you like
+        you can include modifiers to apply before attaching to the class as in
+        the following case where we construct a ``staticmethod``.
+
+            >>> @Stream.register_api(staticmethod)
+            ... class foo(Stream):
+            ...     ...
+
+            >>> Stream.foo(...)  # Foo operates as a static method
+
+        You can also provide an optional ``attribute_name`` argument to control
+        the name of the attribute your callable will be attached as.
+
+            >>> @Stream.register_api(attribute_name="bar")
+            ... class foo(Stream):
+            ...     ...
+
+            >> Stream().bar(...)  # foo was actually attached as bar
+        """
+        def _(func):
+            @functools.wraps(func)
+            def wrapped(*args, **kwargs):
+                return func(*args, **kwargs)
+            name = attribute_name if attribute_name else func.__name__
+            setattr(cls, name, modifier(wrapped))
+            return func
+        return _
+
+    @classmethod
+    def register_plugin_entry_point(cls, entry_point, modifier=identity):
+        if hasattr(cls, entry_point.name):
+            raise ValueError(
+                f"Can't add {entry_point.name} from {entry_point.module_name} "
+                f"to {cls.__name__}: duplicate method name."
+            )
+
+        def stub(*args, **kwargs):
+            """ Entrypoints-based streamz plugin. Will be loaded on first call. """
+            node = entry_point.load()
+            if not issubclass(node, Stream):
+                raise TypeError(
+                    f"Error loading {entry_point.name} "
+                    f"from module {entry_point.module_name}: "
+                    f"{node.__class__.__name__} must be a subclass of Stream"
+                )
+            if getattr(cls, entry_point.name).__name__ == "stub":
+                cls.register_api(
+                    modifier=modifier, attribute_name=entry_point.name
+                )(node)
+            return node(*args, **kwargs)
+        cls.register_api(modifier=modifier, attribute_name=entry_point.name)(stub)
+
+
+class Stream(APIRegisterMixin):
     """ A Stream is an infinite sequence of data.
 
     Streams subscribe to each other passing and transforming data between them.
@@ -179,6 +251,8 @@ class Stream(object):
                  loop=None, asynchronous=None, ensure_io_loop=False):
         self.name = stream_name
         self.downstreams = OrderedWeakrefSet()
+        self.current_value = None
+        self.current_metadata = None
         if upstreams is not None:
             self.upstreams = list(upstreams)
         elif upstream is not None:
@@ -267,79 +341,15 @@ class Stream(object):
         classes which handle stream specific buffers/caches"""
         self.upstreams.remove(upstream)
 
-    @classmethod
-    def register_api(cls, modifier=identity, attribute_name=None):
-        """ Add callable to Stream API
-
-        This allows you to register a new method onto this class.  You can use
-        it as a decorator.::
-
-            >>> @Stream.register_api()
-            ... class foo(Stream):
-            ...     ...
-
-            >>> Stream().foo(...)  # this works now
-
-        It attaches the callable as a normal attribute to the class object.  In
-        doing so it respects inheritance (all subclasses of Stream will also
-        get the foo attribute).
-
-        By default callables are assumed to be instance methods.  If you like
-        you can include modifiers to apply before attaching to the class as in
-        the following case where we construct a ``staticmethod``.
-
-            >>> @Stream.register_api(staticmethod)
-            ... class foo(Stream):
-            ...     ...
-
-            >>> Stream.foo(...)  # Foo operates as a static method
-
-        You can also provide an optional ``attribute_name`` argument to control
-        the name of the attribute your callable will be attached as.
-
-            >>> @Stream.register_api(attribute_name="bar")
-            ... class foo(Stream):
-            ...     ...
-
-            >> Stream().bar(...)  # foo was actually attached as bar
-        """
-        def _(func):
-            @functools.wraps(func)
-            def wrapped(*args, **kwargs):
-                return func(*args, **kwargs)
-            name = attribute_name if attribute_name else func.__name__
-            setattr(cls, name, modifier(wrapped))
-            return func
-        return _
-
-    @classmethod
-    def register_plugin_entry_point(cls, entry_point, modifier=identity):
-        if hasattr(cls, entry_point.name):
-            raise ValueError(
-                f"Can't add {entry_point.name} from {entry_point.module_name} "
-                f"to {cls.__name__}: duplicate method name."
-            )
-
-        def stub(*args, **kwargs):
-            """ Entrypoints-based streamz plugin. Will be loaded on first call. """
-            node = entry_point.load()
-            if not issubclass(node, Stream):
-                raise TypeError(
-                    f"Error loading {entry_point.name} "
-                    f"from module {entry_point.module_name}: "
-                    f"{node.__class__.__name__} must be a subclass of Stream"
-                )
-            if getattr(cls, entry_point.name).__name__ == "stub":
-                cls.register_api(
-                    modifier=modifier, attribute_name=entry_point.name
-                )(node)
-            return node(*args, **kwargs)
-        cls.register_api(modifier=modifier, attribute_name=entry_point.name)(stub)
-
     def start(self):
         """ Start any upstream sources """
         for upstream in self.upstreams:
             upstream.start()
+
+    def stop(self):
+        """ Stop upstream sources """
+        for upstream in self.upstreams:
+            upstream.stop()
 
     def __str__(self):
         s_list = []
@@ -430,6 +440,8 @@ class Stream(object):
             A reference counter used to check when data is done
 
         """
+        self.current_value = x
+        self.current_metadata = metadata
         if metadata:
             self._retain_refs(metadata, len(self.downstreams))
         else:

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -560,13 +560,6 @@ class Stream(APIRegisterMixin):
         """ Only pass through elements for which the predicate returns False """
         return self.filter(lambda x: not predicate(x))
 
-    def stop(self):
-        """Call on any stream node to halt all upstream sources"""
-        prev, s = self.upstream, self
-        while s:
-            prev, s = s, s.upstream
-        prev.stopped = True
-
     @property
     def scan(self):
         return self.accumulate

--- a/streamz/dataframe/core.py
+++ b/streamz/dataframe/core.py
@@ -344,7 +344,8 @@ class DataFrame(Frame, _DataFrameMixin):
     @property
     def plot(self):
         try:
-            import hvplot.streamz
+            # import has side-effect of attaching .hvplot attribute
+            import hvplot.streamz  # # noqa: F401
         except ImportError as err:  # pragma: no cover
             raise ImportError("Streamz dataframe plotting requires hvplot") from err
         return self.hvplot

--- a/streamz/dataframe/core.py
+++ b/streamz/dataframe/core.py
@@ -326,6 +326,10 @@ class DataFrame(Frame, _DataFrameMixin):
                 example = kwargs.get('example')
             elif len(args) > 1:
                 example = args[1]
+            if callable(example):
+                example = example()
+                kwargs["example"] = example
+
             self._subtype = get_base_frame_type(self.__class__.__name__,
                                                 is_dataframe_like, example)
             super(DataFrame, self).__init__(*args, **kwargs)
@@ -336,6 +340,14 @@ class DataFrame(Frame, _DataFrameMixin):
         if list(x.columns) != list(self.example.columns):
             raise IndexError("Input expected to have columns %s, got %s" %
                              (self.example.columns, x.columns))
+
+    @property
+    def plot(self):
+        try:
+            import hvplot.streamz
+        except ImportError as err:  # pragma: no cover
+            raise ImportError("Streamz dataframe plotting requires hvplot") from err
+        return self.hvplot
 
 
 class _SeriesMixin(object):

--- a/streamz/dataframe/core.py
+++ b/streamz/dataframe/core.py
@@ -876,7 +876,7 @@ class PeriodicDataFrame(DataFrame):
         self.loop = source.loop
         self.interval = pd.Timedelta(interval).total_seconds()
         self.source = source
-        self.continue_ = [True]
+        self.continue_ = [False]  # like the oppose of self.stopped
         self.kwargs = kwargs
 
         stream = self.source.map(
@@ -889,8 +889,10 @@ class PeriodicDataFrame(DataFrame):
             self.start()
 
     def start(self):
-        self.loop.add_callback(self._cb, self.interval, self.source,
-                               self.continue_)
+        if not self.continue_[0]:
+            self.continue_[0] = True
+            self.loop.add_callback(self._cb, self.interval, self.source,
+                                   self.continue_)
 
     def __del__(self):
         self.stop()
@@ -924,8 +926,9 @@ class Random(PeriodicDataFrame):
     """
 
     def __init__(self, freq='100ms', interval='500ms', dask=False,
-                 datafn=random_datablock):
-        super(Random, self).__init__(datafn, interval, dask, freq=pd.Timedelta(freq))
+                 start=True, datafn=random_datablock):
+        super(Random, self).__init__(datafn, interval, dask, start,
+                                     freq=pd.Timedelta(freq))
 
 
 _stream_types['streaming'].append((is_dataframe_like, DataFrame))

--- a/streamz/dataframe/core.py
+++ b/streamz/dataframe/core.py
@@ -892,9 +892,7 @@ class PeriodicDataFrame(DataFrame):
         self.continue_ = [False]  # like the oppose of self.stopped
         self.kwargs = kwargs
 
-        stream = self.source.map(
-            lambda x, continue_=self.continue_: datafn(continue_=continue_, **x, **kwargs)
-        )
+        stream = self.source.map(lambda x: datafn(**x, **kwargs))
         example = datafn(last=pd.Timestamp.now(), now=pd.Timestamp.now(), **kwargs)
 
         super(PeriodicDataFrame, self).__init__(stream, example)

--- a/streamz/dataframe/tests/test_dataframes.py
+++ b/streamz/dataframe/tests/test_dataframes.py
@@ -557,7 +557,6 @@ def test_gc():
     a = DataFrame({'volatility': sdf.x.rolling('100ms').var(),
                             'sub': sdf.x - sdf.x.rolling('100ms').mean()})
     n = len(sdf.stream.downstreams)
-    yield gen.sleep(0.1)
     a = DataFrame({'volatility': sdf.x.rolling('100ms').var(),
                             'sub': sdf.x - sdf.x.rolling('100ms').mean()})
     yield gen.sleep(0.1)
@@ -566,6 +565,7 @@ def test_gc():
     yield gen.sleep(0.1)
     a = DataFrame({'volatility': sdf.x.rolling('100ms').var(),
                             'sub': sdf.x - sdf.x.rolling('100ms').mean()})
+    yield gen.sleep(0.1)
 
     assert len(sdf.stream.downstreams) == n
     del a

--- a/streamz/tests/test_sources.py
+++ b/streamz/tests/test_sources.py
@@ -141,10 +141,10 @@ def test_from_iterable():
 def test_from_iterable_backpressure():
     it = iter(range(5))
     source = Source.from_iterable(it)
-    L = source.rate_limit(0.01).sink_to_list()
+    L = source.rate_limit(0.1).sink_to_list()
     source.start()
 
-    wait_for(lambda: L == [0], 1)
+    wait_for(lambda: L == [0], 1, period=0.01)
     assert next(it) == 2  # 1 is in blocked _emit
 
 


### PR DESCRIPTION
https://github.com/intake/intake-streamz coming soon

Changes:
- a `current_value` attribute that holds the most recently emitted thing from a stream (and is *not* part of reference counting, but very useful for introspection)
- make API registering a mixin and apply to `DataFrame`, with only one method right now: `from_periodic`
- add `start` and `stop` methods to `DataFrame`, and make these actions work wherever in a pipeline they are called