### PR TITLE
Allow example for dataframe to not be a dataframe

### DIFF
--- a/streamz/collection.py
+++ b/streamz/collection.py
@@ -177,10 +177,7 @@ class Streaming(OperatorMixin, core.APIRegisterMixin):
         assert example is not None
         self.example = example
         if not isinstance(self.example, self._subtype):
-            msg = ("For streaming type %s we expect an example of type %s. "
-                   "Got %s") % (type(self).__name__, self._subtype.__name__,
-                                str(self.example))
-            raise TypeError(msg)
+            self.example = self._subtype(example)
         assert isinstance(self.example, self._subtype)
         self.stream = stream or Stream()
         if stream_type:

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 from collections import deque, defaultdict
 from datetime import timedelta
 import functools

--- a/streamz/dataframe/core.py
+++ b/streamz/dataframe/core.py
@@ -6,8 +6,6 @@ import numpy as np
 import pandas as pd
 import toolz
 
-from tornado import gen
-
 from ..collection import Streaming, _stream_types, OperatorMixin
 from ..sources import Source
 from ..utils import M
@@ -1049,7 +1047,7 @@ class PeriodicDataFrame(DataFrame):
     async def _cb(interval, source, continue_):
         last = pd.Timestamp.now()
         while continue_[0]:
-            await gen.sleep(interval)
+            await asyncio.sleep(interval)
             now = pd.Timestamp.now()
             await asyncio.gather(*source._emit(dict(last=last, now=now)))
             last = now

--- a/streamz/dataframe/tests/test_dataframe_utils.py
+++ b/streamz/dataframe/tests/test_dataframe_utils.py
@@ -18,14 +18,14 @@ def test_utils_get_base_frame_type_pandas():
     with pytest.raises(TypeError):
         get_base_frame_type("Index", is_index_like, df)
 
-    with pytest.raises(TypeError):
-        get_base_frame_type("DataFrame", is_dataframe_like, df.x)
+    # casts Series to DataFrame, if that's what we ask for
+    assert pd.DataFrame == get_base_frame_type("DataFrame", is_dataframe_like, df.x)
     assert pd.Series == get_base_frame_type("Series", is_series_like, df.x)
     with pytest.raises(TypeError):
         get_base_frame_type("Index", is_index_like, df.x)
 
-    with pytest.raises(TypeError):
-        get_base_frame_type("DataFrame", is_dataframe_like, df.index)
+    # casts Series to DataFrame, if that's what we ask for
+    assert pd.DataFrame == get_base_frame_type("DataFrame", is_dataframe_like, df.index)
     with pytest.raises(TypeError):
         get_base_frame_type("Series", is_series_like, df.index)
     assert issubclass(get_base_frame_type("Index", is_index_like, df.index), pd.Index)

--- a/streamz/dataframe/utils.py
+++ b/streamz/dataframe/utils.py
@@ -39,9 +39,13 @@ def get_base_frame_type(frame_name, is_frame_like, example=None):
     if example is None:
         raise TypeError("Missing required argument:'example'")
     if not is_frame_like(example):
-        msg = "Streaming {0} expects an example of {0} like objects. Got: {1}."\
-                                             .format(frame_name, example)
-        raise TypeError(msg)
+        try:
+            import pandas as pd
+            example = pd.DataFrame(example)
+        except (TypeError, ValueError) as e:
+            msg = "Streaming {0} expects an example of {0} like objects. Got: {1}."\
+                                                 .format(frame_name, example)
+            raise TypeError(msg) from e
     return type(example)
 
 

--- a/streamz/dataframe/utils.py
+++ b/streamz/dataframe/utils.py
@@ -38,14 +38,14 @@ def get_base_frame_type(frame_name, is_frame_like, example=None):
        Returns the base type of streaming objects if type checks pass."""
     if example is None:
         raise TypeError("Missing required argument:'example'")
-    if not is_frame_like(example):
-        try:
-            import pandas as pd
-            example = pd.DataFrame(example)
-        except (TypeError, ValueError) as e:
-            msg = "Streaming {0} expects an example of {0} like objects. Got: {1}."\
-                                                 .format(frame_name, example)
-            raise TypeError(msg) from e
+    if is_frame_like is is_dataframe_like and not is_frame_like(example):
+        import pandas as pd
+        example = pd.DataFrame(example)
+
+    elif not is_frame_like(example):
+        msg = "Streaming {0} expects an example of {0} like objects. Got: {1}."\
+                                             .format(frame_name, example)
+        raise TypeError(msg)
     return type(example)
 
 

--- a/streamz/utils_test.py
+++ b/streamz/utils_test.py
@@ -1,3 +1,4 @@
+import asyncio
 from contextlib import contextmanager
 import logging
 import os
@@ -116,11 +117,10 @@ def wait_for(predicate, timeout, fail_func=None, period=0.001):
             pytest.fail("condition not reached within %s seconds" % timeout)
 
 
-@gen.coroutine
-def await_for(predicate, timeout, fail_func=None, period=0.001):
+async def await_for(predicate, timeout, fail_func=None, period=0.001):
     deadline = time() + timeout
     while not predicate():
-        yield gen.sleep(period)
+        await asyncio.sleep(period)
         if time() > deadline:  # pragma: no cover
             if fail_func is not None:
                 fail_func()


### PR DESCRIPTION
Allows anything that can be interpreted as a dataframe, e.g. dict