### PR TITLE
Fix  `apply` import from `dask`

### DIFF
--- a/streamz/dask.py
+++ b/streamz/dask.py
@@ -4,7 +4,7 @@ from operator import getitem
 
 from tornado import gen
 
-from dask.compatibility import apply
+from dask.utils import apply
 from distributed.client import default_client
 
 from .core import Stream


### PR DESCRIPTION
In a recent dask PR: https://github.com/dask/dask/pull/7801, `apply` was removed from `dask.compatibility`. This PR fixes the issue here and is backward compatible.