### PR TITLE
Generic exception handling

### DIFF
--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -16,6 +16,7 @@ from tornado.ioloop import IOLoop
 import streamz as sz
 
 from streamz import RefCounter
+from streamz.core import InvalidDataError
 from streamz.sources import sink_to_file
 from streamz.utils_test import (inc, double, gen_test, tmpfile, captured_logger,   # noqa: F401
         clean, await_for, metadata, wait_for)  # noqa: F401
@@ -933,7 +934,7 @@ def test_pluck():
     assert L == [2]
     a.emit([4, 5, 6, 7, 8, 9])
     assert L == [2, 5]
-    with pytest.raises(IndexError):
+    with pytest.raises(InvalidDataError):
         a.emit([1])
 
 
@@ -945,7 +946,7 @@ def test_pluck_list():
     assert L == [(1, 3)]
     a.emit([4, 5, 6, 7, 8, 9])
     assert L == [(1, 3), (4, 6)]
-    with pytest.raises(IndexError):
+    with pytest.raises(InvalidDataError):
         a.emit([1])
 
 
@@ -1579,7 +1580,7 @@ def test_map_errors_log():
 def test_map_errors_raises():
     a = Stream()
     b = a.map(lambda x: 1 / x)  # noqa: F841
-    with pytest.raises(ZeroDivisionError):
+    with pytest.raises(InvalidDataError):
         a.emit(0)
 
 
@@ -1599,7 +1600,7 @@ def test_accumulate_errors_log():
 def test_accumulate_errors_raises():
     a = Stream()
     b = a.accumulate(lambda x, y: x / y, with_state=True)  # noqa: F841
-    with pytest.raises(ZeroDivisionError):
+    with pytest.raises(InvalidDataError):
         a.emit(1)
         a.emit(0)
 


### PR DESCRIPTION
Work in progress: A (naive?) stab at generic exception handling within streamz.

This PR attaches an exception handler to each Stream object that acts as an optional start of a new pipeline branch.
```python
from streamz import Stream

def problem(item):
    raise ValueError

s = Stream()
mapper = s.map(problem)

# Default
s.emit(123) # <-- raises and InvalidDataError

# explicit silencing of exceptions
mapper.on_exception().silent = True
s.emit(123) # No exception 

# Do something with the exception and the data that caused it
def problem_solver(item):
    data_that_caused_the_problem, resulting_exception = item
    # Do something
mapper.on_exception().map(problem_solver)
s.emit(123) # The exception and the faulty data is pushed downstream in the on_exception branch
```

This PR requires some linting, a few tests fail (but nothing major it seems) and updated docs. Consider it a starting point for discussion, mainly in relation to #86. Would appreciate some feedback on this before I continue.



