### PR TITLE
Show streamz.DataFrame in notebook with ipywidgets>8 

### DIFF
--- a/streamz/core.py
+++ b/streamz/core.py
@@ -379,13 +379,14 @@ class Stream(APIRegisterMixin):
     __repr__ = __str__
 
     def _ipython_display_(self, **kwargs):  # pragma: no cover
+        # Since this function is only called by jupyter, this import must succeed
+        from IPython.display import HTML, display
+
         try:
             import ipywidgets
             from IPython.core.interactiveshell import InteractiveShell
             output = ipywidgets.Output(_view_count=0)
         except ImportError:
-            # since this function is only called by jupyter, this import must succeed
-            from IPython.display import display, HTML
             if hasattr(self, '_repr_html_'):
                 return display(HTML(self._repr_html_()))
             else:
@@ -420,7 +421,11 @@ class Stream(APIRegisterMixin):
 
         output.observe(remove_stream, '_view_count')
 
-        return output._ipython_display_(**kwargs)
+        if hasattr(output, "_repr_mimebundle_"):
+            data = output._repr_mimebundle_(**kwargs)
+            return display(data, raw=True)
+        else:
+            return output._ipython_display_(**kwargs)
 
     def _emit(self, x, metadata=None):
         """


### PR DESCRIPTION
ipywidgets version 8.0 no longer uses `_ipython_display_`, giving the following error in a notebook when trying to display a streamz dataframe.:

![image](https://user-images.githubusercontent.com/19758978/189519610-944e370f-a0d7-49e4-9944-1443c553c6b0.png)

This PR adds a check for `__repr_mimebundle__` and uses it if it exists.

https://user-images.githubusercontent.com/19758978/189519705-e60d336d-ccfe-491a-a84b-fe49b0c9c30b.mp4

