### PR TITLE
Add Python 3.13 to CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        CONDA_ENV: [py39, py310, py311, py312]
+        CONDA_ENV: [py39, py310, py311, py312, py313]
     # env:
       # STREAMZ_LAUNCH_KAFKA: true
 

--- a/ci/environment-py313.yml
+++ b/ci/environment-py313.yml
@@ -1,0 +1,27 @@
+name: test_env
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.13
+  - pytest
+  - flake8
+  - black
+  - isort
+  - tornado
+  - toolz
+  - librdkafka
+  - dask
+  - distributed
+  - pandas
+  - python-confluent-kafka
+  - codecov
+  - coverage
+  - networkx
+  - graphviz
+  - pytest-asyncio
+  - python-graphviz
+  - bokeh
+  - ipywidgets
+  - flaky
+  - pytest-cov


### PR DESCRIPTION
* add conda environment file for 3.13
* add py313 to test.strategy.matrix

I noticed that there are several DeprecationWarnings around event loop uses. I can include changes for resolving those as well. It seems like they might be real problems in the 3.14+ world as there are major changes around asyncio there:
* 3.14 turns off the creation an event loop in `get_event_loop` and strongly encourages just using `get_running_loop`
* 3.14 deprecates event loop policies entirely which are scheduled for removal in 3.16
* Tornado 6.5 IOLoop is basically just a wrapper for asyncio according to their docs and 6.2+ changes several behaviors of the IOLoop

Most of the changes were just in the test cases, but the API change in Tornado impacts streamz/core.py as that is eagerly trying to create an event loop in an incorrect place.