### PR TITLE
Add missing RTD configuration file, which is obligatory today

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,21 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+
+# Details
+# - https://docs.readthedocs.com/platform/stable/config-file/v2.html
+
+# Required
+version: 2
+
+build:
+  os: "ubuntu-24.04"
+  tools:
+    python: "3.14"
+
+# Build documentation in the docs/source/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements-docs.txt


### PR DESCRIPTION
## Problem
It looks like the RTD [configuration file](https://docs.readthedocs.com/platform/stable/config-file/v2.html) was missing. It was optional before, but is obligatory today.

## References
- https://github.com/python-streamz/streamz/pull/487#issuecomment-3667244693