### PR TITLE
CI: Cancel redundant in-progress workflow runs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,6 +5,7 @@ on:
     branches: "*"
   pull_request:
     branches: master
+  workflow_dispatch:
 
 # Cancel redundant in-progress workflow runs.
 concurrency:


### PR DESCRIPTION
When force-pushing to a PR where its GHA workflows are currently running, let's cancel them, because they became redundant at this moment. While at it, also add a little option to make it possible to invoke the workflow manually from the user interface.