### PR TITLE
RTD: Install package. Synchronize dependency list.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,4 +18,10 @@ sphinx:
 
 python:
   install:
+
+    # Install package.
+    - method: pip
+      path: .
+
+    # Install Sphinx.
     - requirements: docs/requirements-docs.txt

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,9 +1,5 @@
 numpydoc
 sphinx
 sphinx_rtd_theme
-tornado
-toolz
-zict
 pandas
-dask
-distributed
+dask[distributed]


### PR DESCRIPTION
## Problem
The RTD build currently fails, because it needs the package itself to be installed, in order to build API docs.

## References
- https://github.com/python-streamz/streamz/pull/488#issuecomment-3667320110