### PR TITLE
Update dockerfile aka Quickstart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,45 +1,50 @@
-FROM python:3.7.5-slim
+# syntax=docker/dockerfile:1
+FROM python:3.14-slim
 USER root
 SHELL ["/bin/bash", "--login", "-c"]
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV SCALA_VERSION 2.11
-ENV KAFKA_VERSION 2.3.0
-ENV KAFKA_HOME /opt/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION"
+ARG DEBIAN_FRONTEND="noninteractive"
+ENV STREAMZ_ENV="streamz-dev"
+ENV SCALA_VERSION="2.13"
+ENV KAFKA_VERSION="4.2.0"
+ENV KAFKA_HOME="/opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION}"
+ARG KAFKA_SRC_TGZ="https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
+
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends wget vim && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Kafka & Expose Port
+RUN wget -q "${KAFKA_SRC_TGZ}" -O "/tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" && \
+    tar xfz "/tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" -C /opt && \
+    rm "/tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
+EXPOSE 9092
 
 # Install conda
 ADD https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh /miniconda.sh
-RUN sh /miniconda.sh -b -p /conda && /conda/bin/conda update -n base conda
+RUN sh /miniconda.sh -b -p /conda && \
+    /conda/bin/conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main && \
+    /conda/bin/conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r && \
+    /conda/bin/conda update -n base conda
 RUN echo "PATH=${PATH}:/conda/bin" >> ~/.bashrc
 
 # Add Streamz source code to the build context
 ADD . /streamz/.
 
 # Create the conda environment
-RUN conda env create --name streamz-dev -f /streamz/conda/environments/streamz_dev.yml
+RUN conda env create --name ${STREAMZ_ENV} -f /streamz/ci/environment-py314.yml
 RUN conda init bash
 
-# Ensures subsequent RUN commands do not need the "conda activate streamz_dev" command
-RUN echo "conda activate streamz_dev" >> ~/.bashrc
-
-# Build streamz from source
-RUN cd /streamz && \
-    python setup.py install
+# Ensures subsequent RUN commands do not need the "conda activate ${STREAMZ_ENV}" command
+RUN echo "conda activate ${STREAMZ_ENV}" >> ~/.bashrc
 
 # Install optional dependencies in the conda environment
 RUN conda install -c conda-forge jupyterlab \
                                  numpy \
-                                 pandas \
-                                 wget \
-                                 vim
+                                 pandas
 
-# Install Kafka
-RUN wget -q http://www.gtlib.gatech.edu/pub/apache/kafka/2.3.0/kafka_2.11-2.3.0.tgz -O /tmp/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz && \
-        tar xfz /tmp/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz -C /opt && \
-        rm /tmp/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz
-
-# Zookeeper & Kafa ports
-EXPOSE 2181
-EXPOSE 9092
+# Build streamz from source
+RUN cd /streamz && \
+    pip install -e . --no-deps
 
 CMD ["/streamz/docker/scripts/entry.sh"]

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,3 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-docker build -t streamz:0.5.2 .
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "${DIR}/.."
+export VERSION=$(python "${DIR}/../setup.py" --version)
+docker build -t "streamz:${VERSION}" .

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,3 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-docker run -p 8888:8888 streamz:0.5.2
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "${DIR}/.."
+export VERSION=$(python "${DIR}/../setup.py" --version)
+docker run --rm -p 8888:8888 "streamz:${VERSION}"

--- a/docker/scripts/entry.sh
+++ b/docker/scripts/entry.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
-
-# Activate the streamz-dev anaconda environment by default
-source activate streamz-dev
-
-# Start Zookeeper
-$KAFKA_HOME/bin/zookeeper-server-start.sh -daemon $KAFKA_HOME/config/zookeeper.properties
+set -euo pipefail
+source ~/.bashrc
 
 # Configure Kafka
 sed -i '/#listeners=PLAINTEXT:\/\/:9092/c\listeners=PLAINTEXT:\/\/localhost:9092' $KAFKA_HOME/config/server.properties


### PR DESCRIPTION
As noted in https://github.com/python-streamz/streamz/issues/469, the Docker materials are completely outdated. I've rebuilt them and tested on Ubuntu 24.04 running native docker. We aren't using anything special, so this should hopefully work generally. I confirmed that the build/run scripts get the jupyter notebook launched and I accessed it via Chrome but I'm not a jupyter user so I did not push on it very much too see if anything is wonky.

I've done a deep clean of the Kafka version that installs into the image as well. We don't have a version constraint on the Kafka version that Streamz interacts with so I moved it to 4.2.0.